### PR TITLE
Changes related to secured files ...

### DIFF
--- a/files/src/main/java/com/fincity/saas/files/configuration/FilesConfiguration.java
+++ b/files/src/main/java/com/fincity/saas/files/configuration/FilesConfiguration.java
@@ -51,7 +51,7 @@ public class FilesConfiguration extends AbstractJooqBaseConfiguration
 
 		return this.springSecurityFilterChain(http, authService, this.objectMapper, matcher,
 
-				"/api/files/static/file/**", "/api/files/internal/**");
+				"/api/files/static/file/**", "/api/files/internal/**", "/api/files/secured/downloadFileByKey/*");
 	}
 
 	@Bean

--- a/files/src/main/java/com/fincity/saas/files/controller/SecuredResourceFileController.java
+++ b/files/src/main/java/com/fincity/saas/files/controller/SecuredResourceFileController.java
@@ -27,7 +27,7 @@ public class SecuredResourceFileController extends AbstractResourceFileControlle
 			@RequestParam(required = false) ChronoUnit timeUnit, @RequestParam(required = false) Long accessLimit,
 			ServerHttpRequest request) {
 
-		return this.service.createSecuredAccess(timeSpan, timeUnit, accessLimit, request.getURI()
+		return this.service.createSecuredAccess(timeSpan, timeUnit, accessLimit, request.getPath()
 				.toString())
 				.map(ResponseEntity::ok);
 	}

--- a/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
@@ -920,17 +920,14 @@ public abstract class AbstractFilesResourceService {
 		boolean ovr = override == null || override.booleanValue();
 		Tuple2<String, String> tup = this.resolvePathWithoutClientCode(this.uriPartImport, uri);
 
+		String resourcePath = tup.getT1();
+
 		if (fp == null || (!fp.filename()
 				.toLowerCase()
 				.endsWith(".zip"))) {
 			return this.msgService.throwMessage(msg -> new GenericException(HttpStatus.BAD_REQUEST, msg),
 					FilesMessageResourceService.UNABLE_TO_READ_UP_FILE);
 		}
-
-		String resourcePath = this.comparePaths(Tuples.of(tup.getT1(), fp.filename()
-				.substring(0, fp.filename()
-						.lastIndexOf('.'))))
-				.getT1();
 
 		return FlatMapUtil.flatMapMono(
 
@@ -981,18 +978,6 @@ public abstract class AbstractFilesResourceService {
 				.subscribeOn(Schedulers.boundedElastic());
 	}
 
-	private Tuple2<String, String> comparePaths(Tuple2<String, String> tuple) {
-
-		if (tuple.getT1()
-				.endsWith(tuple.getT2()))
-
-			return Tuples.of(tuple.getT1()
-					.substring(0, tuple.getT1()
-							.indexOf(tuple.getT2())),
-					tuple.getT2());
-
-		return tuple;
-	}
 
 	private String parentOf(String name) {
 		int ind = name.lastIndexOf('/');

--- a/files/src/main/java/com/fincity/saas/files/service/FilesMessageResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/FilesMessageResourceService.java
@@ -46,6 +46,7 @@ public class FilesMessageResourceService extends AbstractMessageService {
 	public static final String IMAGE_FILE_REQUIRED = "image_file_required";
 	public static final String IMAGE_TRANSFORM_ERROR = "image_transform_error";
 	public static final String UNABLE_TO_COPY_THE_IMAGE_FILE = "unable_to_copy_the_image_file";
+	public static final String INVALID_KEY = "invalid_key";
 
 	public FilesMessageResourceService() {
 

--- a/files/src/main/java/com/fincity/saas/files/service/FilesSecuredAccessService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/FilesSecuredAccessService.java
@@ -5,8 +5,12 @@ import static com.fincity.nocode.reactor.util.FlatMapUtil.flatMapMono;
 import java.time.LocalDateTime;
 
 import org.jooq.types.ULong;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import com.fincity.saas.commons.exeception.GenericException;
 import com.fincity.saas.commons.jooq.service.AbstractJOOQDataService;
 import com.fincity.saas.commons.util.BooleanUtil;
 import com.fincity.saas.commons.util.LogUtil;
@@ -21,6 +25,9 @@ import reactor.util.context.Context;
 @Service
 public class FilesSecuredAccessService extends
         AbstractJOOQDataService<FilesSecuredAccessKeysRecord, ULong, FilesSecuredAccessKey, FilesSecuredAccessKeyDao> {
+
+	@Autowired
+	public FilesMessageResourceService messageResourceService;
 
 	public Mono<FilesSecuredAccessKey> getAccessRecordByPath(String key) {
 		return this.dao.getAccessByKey(key);
@@ -53,6 +60,9 @@ public class FilesSecuredAccessService extends
 		                                        "FilesSecuredAccessService.getAccessPathByKey"))
 
 						))
+					.switchIfEmpty(this.messageResourceService.throwMessage(msg -> 
+						new GenericException(HttpStatus.NOT_FOUND, msg), FilesMessageResourceService.INVALID_KEY))
+
 		        .contextWrite(Context.of(LogUtil.METHOD_NAME, "FilesSecuredAccessService.getAccessPathByKey"));
 	}
 

--- a/files/src/main/resources/messages_en.properties
+++ b/files/src/main/resources/messages_en.properties
@@ -29,3 +29,4 @@ image_file_required=Uploaded file should be of image type
 image_transform_error=Selected image cannot be edited
 unable_to_copy_the_image_file=Unable to copy the image file
 missing_field=$ is/are missing
+invalid_key=Cannot be accessed with the given key or access limit reached


### PR DESCRIPTION
... updated secured resource service file as not able to create key it was taking complete path while generating the key and added throw clause when the access to resource was expired or limit reached. Added secured download by key to exclusion list as access token not required for this scenario as this resource will only be accessed by that specific user only. 