### PR TITLE
Add support for JPG format and enforce RGB for JPEG conversion

### DIFF
--- a/files/src/main/java/com/fincity/saas/files/model/DownloadOptions.java
+++ b/files/src/main/java/com/fincity/saas/files/model/DownloadOptions.java
@@ -42,6 +42,7 @@ public class DownloadOptions {
         avif,
         webp,
         jpeg,
+        jpg,
         png
     }
 
@@ -66,5 +67,9 @@ public class DownloadOptions {
             && gravity == Gravity.auto
             && background == null
             && format == Format.general;
+    }
+
+    public Format getFormat() {
+        return format == Format.jpg ? Format.jpeg : format;
     }
 }

--- a/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
@@ -457,7 +457,19 @@ public abstract class AbstractFilesResourceService {
                 processed = original;
         }
 
+        if (targetFormat == DownloadOptions.Format.jpeg && processed.getType() != BufferedImage.TYPE_INT_RGB) {
+            return convertToRGB(processed);
+        }
+
         return processed;
+    }
+
+    private BufferedImage convertToRGB(BufferedImage image) {
+        BufferedImage rgbImage = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = rgbImage.createGraphics();
+        g2d.drawImage(image, 0, 0, null);
+        g2d.dispose();
+        return rgbImage;
     }
 
     // Example helper methods using Scalr to handle each fit case:


### PR DESCRIPTION
Introduced JPG as a recognized format, mapping it to JPEG for consistency. Added a method to convert images to RGB when the target format is JPEG to ensure proper compatibility. This prevents errors with non-RGB image types during processing.