### PR TITLE
Add image handling enhancements and folder access rules

### DIFF
--- a/commons-security/src/main/java/com/fincity/saas/commons/security/feign/IFeignSecurityService.java
+++ b/commons-security/src/main/java/com/fincity/saas/commons/security/feign/IFeignSecurityService.java
@@ -16,15 +16,14 @@ import com.fincity.saas.commons.security.dto.App;
 import com.fincity.saas.commons.security.dto.Client;
 import com.fincity.saas.commons.security.jwt.ContextAuthentication;
 
-import reactivefeign.spring.config.ReactiveFeignClient;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
-@ReactiveFeignClient(name = "security")
+@reactivefeign.spring.config.ReactiveFeignClient(name = "security")
 public interface IFeignSecurityService {
 
     @GetMapping("${security.feign.contextAuthentication:/api/security/internal/securityContextAuthentication}")
-    public Mono<ContextAuthentication> contextAuthentication(
+    Mono<ContextAuthentication> contextAuthentication(
         @RequestHeader(name = "Authorization", required = false) String authorization,
         @RequestHeader("X-Forwarded-Host") String forwardedHost,
         @RequestHeader("X-Forwarded-Port") String forwardedPort,
@@ -32,60 +31,60 @@ public interface IFeignSecurityService {
         @RequestHeader("appCode") String appCode);
 
     @GetMapping("${security.feign.isBeingManaged:/api/security/clients/internal/isBeingManaged}")
-    public Mono<Boolean> isBeingManaged(@RequestParam String managingClientCode, @RequestParam String clientCode);
+    Mono<Boolean> isBeingManaged(@RequestParam String managingClientCode, @RequestParam String clientCode);
 
     @GetMapping("${security.feign.isBeingManagedById:/api/security/clients/internal/isBeingManagedById}")
-    public Mono<Boolean> isBeingManagedById(@RequestParam BigInteger managingClientId,
-                                            @RequestParam BigInteger clientId);
+    Mono<Boolean> isBeingManagedById(@RequestParam BigInteger managingClientId,
+                                     @RequestParam BigInteger clientId);
 
     @GetMapping("${security.feign.getClientById:/api/security/clients/internal/getClientById}")
-    public Mono<Client> getClientById(@RequestParam BigInteger clientId);
+    Mono<Client> getClientById(@RequestParam BigInteger clientId);
 
     @GetMapping("${security.feign.getClientByCode:/api/security/clients/internal/getClientByCode}")
-    public Mono<Client> getClientByCode(@RequestParam String clientCode);
+    Mono<Client> getClientByCode(@RequestParam String clientCode);
 
     @GetMapping("${security.feign.isUserBeingManaged:/api/security/clients/internal/isUserBeingManaged}")
-    public Mono<Boolean> isUserBeingManaged(@RequestParam BigInteger userId, @RequestParam String clientCode);
+    Mono<Boolean> isUserBeingManaged(@RequestParam BigInteger userId, @RequestParam String clientCode);
 
     @GetMapping("${security.feign.hasReadAccess:/api/security/applications/internal/hasReadAccess}")
-    public Mono<Boolean> hasReadAccess(@RequestParam String appCode, @RequestParam String clientCode);
+    Mono<Boolean> hasReadAccess(@RequestParam String appCode, @RequestParam String clientCode);
 
     @GetMapping("${security.feign.hasWriteAccess:/api/security/applications/internal/hasWriteAccess}")
-    public Mono<Boolean> hasWriteAccess(@RequestParam String appCode, @RequestParam String clientCode);
+    Mono<Boolean> hasWriteAccess(@RequestParam String appCode, @RequestParam String clientCode);
 
     @GetMapping("${security.feign.validClientCode:/api/security/clients/internal/validateClientCode}")
-    public Mono<Boolean> validClientCode(@RequestParam String clientCode);
+    Mono<Boolean> validClientCode(@RequestParam String clientCode);
 
     @GetMapping("${security.feign.hasWriteAccess:/api/security/applications/internal/appInheritance}")
-    public Mono<List<String>> appInheritance(@RequestParam String appCode, @RequestParam String urlClientCode,
-                                             @RequestParam String clientCode);
+    Mono<List<String>> appInheritance(@RequestParam String appCode, @RequestParam String urlClientCode,
+                                      @RequestParam String clientCode);
 
     @GetMapping("${security.feign.token:/api/security/ssl/token/{token}}")
-    public Mono<String> token(@PathVariable("token") String token);
+    Mono<String> token(@PathVariable("token") String token);
 
     @GetMapping("${security.feign.getAppByCode:/api/security/applications/internal/appCode/{appCode}}")
-    public Mono<App> getAppByCode(@PathVariable("appCode") String appCode);
+    Mono<App> getAppByCode(@PathVariable("appCode") String appCode);
 
     @GetMapping("${security.feign.getAppByCode:/api/security/applications/internal/explicitInfo/{appCode}}")
-    public Mono<App> getAppExplicitInfoByCode(@PathVariable("appCode") String appCode);
+    Mono<App> getAppExplicitInfoByCode(@PathVariable("appCode") String appCode);
 
     @GetMapping("${security.feign.getAppById:/api/security/applications/{id}}")
-    public Mono<App> getAppById(@RequestHeader(name = "Authorization", required = false) String authorization,
+    Mono<App> getAppById(@RequestHeader(name = "Authorization", required = false) String authorization,
+                         @RequestHeader("X-Forwarded-Host") String forwardedHost,
+                         @RequestHeader("X-Forwarded-Port") String forwardedPort,
+                         @RequestHeader("clientCode") String clientCode,
+                         @RequestHeader("appCode") String headerAppCode, @PathVariable("id") String id);
+
+    @DeleteMapping("${security.feign.deleteByAppId:/api/security/applications/{id}}")
+    Mono<Boolean> deleteByAppId(@RequestHeader(name = "Authorization") String authorization,
                                 @RequestHeader("X-Forwarded-Host") String forwardedHost,
                                 @RequestHeader("X-Forwarded-Port") String forwardedPort,
                                 @RequestHeader("clientCode") String clientCode,
-                                @RequestHeader("appCode") String headerAppCode, @PathVariable("id") String id);
-
-    @DeleteMapping("${security.feign.deleteByAppId:/api/security/applications/{id}}")
-    public Mono<Boolean> deleteByAppId(@RequestHeader(name = "Authorization") String authorization,
-                                       @RequestHeader("X-Forwarded-Host") String forwardedHost,
-                                       @RequestHeader("X-Forwarded-Port") String forwardedPort,
-                                       @RequestHeader("clientCode") String clientCode,
-                                       @RequestHeader("appCode") String headerAppCode,
-                                       @PathVariable("id") BigInteger id);
+                                @RequestHeader("appCode") String headerAppCode,
+                                @PathVariable("id") BigInteger id);
 
     @GetMapping("${security.feign.transport:/api/security/transports/makeTransport}")
-    public Mono<Map<String, Object>> makeTransport(
+    Mono<Map<String, Object>> makeTransport(
         @RequestHeader(name = "Authorization", required = false) String authorization,
         @RequestHeader("X-Forwarded-Host") String forwardedHost,
         @RequestHeader("X-Forwarded-Port") String forwardedPort,
@@ -94,7 +93,7 @@ public interface IFeignSecurityService {
         @RequestParam("applicationCode") String applicationCode);
 
     @PostMapping("${security.feign.createApp:/api/security/applications/}")
-    public Mono<App> createApp(
+    Mono<App> createApp(
         @RequestHeader(name = "Authorization", required = false) String authorization,
         @RequestHeader("X-Forwarded-Host") String forwardedHost,
         @RequestHeader("X-Forwarded-Port") String forwardedPort,
@@ -103,7 +102,7 @@ public interface IFeignSecurityService {
         @RequestBody App application);
 
     @PostMapping("${security.feign.transportApply:/api/security/transports/createAndApply}")
-    public Mono<Boolean> createAndApplyTransport(
+    Mono<Boolean> createAndApplyTransport(
         @RequestHeader(name = "Authorization", required = false) String authorization,
         @RequestHeader("X-Forwarded-Host") String forwardedHost,
         @RequestHeader("X-Forwarded-Port") String forwardedPort,
@@ -112,7 +111,7 @@ public interface IFeignSecurityService {
         @RequestBody Object securityDefinition);
 
     @GetMapping("${security.feign.findBaseClientCodeForOverride:/api/security/applications/findBaseClientCode/{applicationCode}}")
-    public Mono<Tuple2<String, Boolean>> findBaseClientCodeForOverride(
+    Mono<Tuple2<String, Boolean>> findBaseClientCodeForOverride(
         @RequestHeader(name = "Authorization", required = false) String authorization,
         @RequestHeader("X-Forwarded-Host") String forwardedHost,
         @RequestHeader("X-Forwarded-Port") String forwardedPort,
@@ -121,25 +120,25 @@ public interface IFeignSecurityService {
         @PathVariable("applicationCode") String applicationCode);
 
     @GetMapping("${security.feign.dependencies:/api/security/applications/internal/dependencies}")
-    public Mono<List<String>> getDependencies(@RequestParam String appCode);
+    Mono<List<String>> getDependencies(@RequestParam String appCode);
 
     @GetMapping("${security.feign.getAppUrl:/api/security/clienturls/internal/applications/property/url}")
-    public Mono<String> getAppUrl(@RequestParam String appCode,
-                                  @RequestParam(required = false) String clientCode);
+    Mono<String> getAppUrl(@RequestParam String appCode,
+                           @RequestParam(required = false) String clientCode);
 
     @DeleteMapping("${security.feign.deleteEveryting:/api/security/applications/{id}}")
-    public Mono<Boolean> deleteEverything(@RequestHeader(name = "Authorization", required = false) String authorization,
-                                          @RequestHeader("X-Forwarded-Host") String forwardedHost,
-                                          @RequestHeader("X-Forwarded-Port") String forwardedPort,
-                                          @RequestHeader("clientCode") String clientCode,
-                                          @RequestHeader("appCode") String headerAppCode,
-                                          @PathVariable("id") final Long id);
+    Mono<Boolean> deleteEverything(@RequestHeader(name = "Authorization", required = false) String authorization,
+                                   @RequestHeader("X-Forwarded-Host") String forwardedHost,
+                                   @RequestHeader("X-Forwarded-Port") String forwardedPort,
+                                   @RequestHeader("clientCode") String clientCode,
+                                   @RequestHeader("appCode") String headerAppCode,
+                                   @PathVariable("id") final Long id);
 
     @GetMapping("${security.feign.hasDeleteAccess:/api/security/applications/hasDeleteAccess}")
-    public Mono<Boolean> hasDeleteAccess(@RequestHeader(name = "Authorization", required = false) String authorization,
-                                         @RequestHeader("X-Forwarded-Host") String forwardedHost,
-                                         @RequestHeader("X-Forwarded-Port") String forwardedPort,
-                                         @RequestHeader("clientCode") String headerClientCode,
-                                         @RequestHeader("appCode") String headerAppCode,
-                                         @RequestParam("deleteAppCode") String deleteAppCode, @RequestParam("deleteClientCode") String deleteClientCode);
+    Mono<Boolean> hasDeleteAccess(@RequestHeader(name = "Authorization", required = false) String authorization,
+                                  @RequestHeader("X-Forwarded-Host") String forwardedHost,
+                                  @RequestHeader("X-Forwarded-Port") String forwardedPort,
+                                  @RequestHeader("clientCode") String headerClientCode,
+                                  @RequestHeader("appCode") String headerAppCode,
+                                  @RequestParam("deleteAppCode") String deleteAppCode, @RequestParam("deleteClientCode") String deleteClientCode);
 }

--- a/files/src/main/java/com/fincity/saas/files/controller/GenericResourceFileController.java
+++ b/files/src/main/java/com/fincity/saas/files/controller/GenericResourceFileController.java
@@ -1,0 +1,65 @@
+package com.fincity.saas.files.controller;
+
+import com.fincity.saas.commons.util.BooleanUtil;
+import com.fincity.saas.files.model.FileDetail;
+import com.fincity.saas.files.model.ImageDetails;
+import com.fincity.saas.files.service.SecuredFileResourceService;
+import com.fincity.saas.files.service.StaticFileResourceService;
+import com.fincity.saas.files.util.ImageDetailsUtil;
+import org.jooq.types.ULong;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("api/files/generic")
+public class GenericResourceFileController {
+
+    private final SecuredFileResourceService securedService;
+    private final StaticFileResourceService staticService;
+
+    public GenericResourceFileController(SecuredFileResourceService securedService,
+                                         StaticFileResourceService staticService) {
+        this.securedService = securedService;
+        this.staticService = staticService;
+    }
+
+    @PostMapping("/client")
+    public Mono<ResponseEntity<FileDetail>> uploadClientImage(
+        @RequestPart(name = "file") Mono<FilePart> filePart,
+        @RequestPart(required = false) String width, @RequestPart(required = false) String height,
+        @RequestPart(required = false) String rotation, @RequestPart(required = false) String cropAreaX,
+        @RequestPart(required = false) String cropAreaY, @RequestPart(required = false) String cropAreaWidth,
+        @RequestPart(required = false) String cropAreaHeight,
+        @RequestPart(required = false) String flipHorizontal,
+        @RequestPart(required = false) String flipVertical, @RequestPart(required = false) String backgroundColor,
+        @RequestParam(name = "clientId", required = false) ULong clientId) {
+
+        ImageDetails imageDetails = ImageDetailsUtil.makeDetails(
+            width, height, rotation, cropAreaX, cropAreaY, cropAreaWidth, cropAreaHeight, flipHorizontal, flipVertical,
+            backgroundColor
+        );
+
+        return filePart.flatMap(fp -> this.staticService.uploadClientImage(fp, imageDetails, clientId)).map(ResponseEntity::ok);
+    }
+
+    @PostMapping("/user")
+    public Mono<ResponseEntity<FileDetail>> uploadUserImage(
+        @RequestPart(name = "file") Mono<FilePart> filePart,
+        @RequestPart(required = false) String width, @RequestPart(required = false) String height,
+        @RequestPart(required = false) String rotation, @RequestPart(required = false) String cropAreaX,
+        @RequestPart(required = false) String cropAreaY, @RequestPart(required = false) String cropAreaWidth,
+        @RequestPart(required = false) String cropAreaHeight,
+        @RequestPart(required = false) String flipHorizontal,
+        @RequestPart(required = false) String flipVertical, @RequestPart(required = false) String backgroundColor,
+        @RequestParam(name = "userId", required = false) ULong userId) {
+
+        ImageDetails imageDetails = ImageDetailsUtil.makeDetails(
+            width, height, rotation, cropAreaX, cropAreaY, cropAreaWidth, cropAreaHeight, flipHorizontal, flipVertical,
+            backgroundColor
+        );
+
+        return filePart.flatMap(fp -> this.securedService.uploadUserImage(fp, imageDetails, userId)).map(ResponseEntity::ok);
+    }
+}

--- a/files/src/main/java/com/fincity/saas/files/controller/GenericResourceFileController.java
+++ b/files/src/main/java/com/fincity/saas/files/controller/GenericResourceFileController.java
@@ -1,16 +1,32 @@
 package com.fincity.saas.files.controller;
 
-import com.fincity.saas.commons.util.BooleanUtil;
+import com.fincity.nocode.reactor.util.FlatMapUtil;
+import com.fincity.saas.commons.exeception.GenericException;
+import com.fincity.saas.commons.util.CommonsUtil;
+import com.fincity.saas.commons.util.LogUtil;
+import com.fincity.saas.files.enums.ImagesFormatForResize;
 import com.fincity.saas.files.model.FileDetail;
 import com.fincity.saas.files.model.ImageDetails;
+import com.fincity.saas.files.service.FilesMessageResourceService;
 import com.fincity.saas.files.service.SecuredFileResourceService;
 import com.fincity.saas.files.service.StaticFileResourceService;
 import com.fincity.saas.files.util.ImageDetailsUtil;
+import com.fincity.saas.files.util.ImageTransformUtil;
 import org.jooq.types.ULong;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.context.Context;
+import reactor.util.function.Tuple3;
+import reactor.util.function.Tuples;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
 
 @RestController
 @RequestMapping("api/files/generic")
@@ -18,11 +34,14 @@ public class GenericResourceFileController {
 
     private final SecuredFileResourceService securedService;
     private final StaticFileResourceService staticService;
+    private final FilesMessageResourceService msgService;
 
     public GenericResourceFileController(SecuredFileResourceService securedService,
-                                         StaticFileResourceService staticService) {
+                                         StaticFileResourceService staticService,
+                                         FilesMessageResourceService msgService) {
         this.securedService = securedService;
         this.staticService = staticService;
+        this.msgService = msgService;
     }
 
     @PostMapping("/client")
@@ -61,5 +80,85 @@ public class GenericResourceFileController {
         );
 
         return filePart.flatMap(fp -> this.securedService.uploadUserImage(fp, imageDetails, userId)).map(ResponseEntity::ok);
+    }
+
+    //Currently only supports jpg and png.
+    @PostMapping("/resize")
+    public Mono<Void> resizeImage(
+        @RequestPart(name = "file") Mono<FilePart> filePart,
+        @RequestPart(required = false) String width, @RequestPart(required = false) String height,
+        @RequestPart(required = false) String rotation, @RequestPart(required = false) String cropAreaX,
+        @RequestPart(required = false) String cropAreaY, @RequestPart(required = false) String cropAreaWidth,
+        @RequestPart(required = false) String cropAreaHeight,
+        @RequestPart(required = false) String flipHorizontal,
+        @RequestPart(required = false) String flipVertical, @RequestPart(required = false) String backgroundColor,
+        @RequestPart(required = false) ImagesFormatForResize toFormat,
+        ServerHttpResponse response) {
+
+        ImageDetails imageDetails = ImageDetailsUtil.makeDetails(
+            width, height, rotation, cropAreaX, cropAreaY, cropAreaWidth, cropAreaHeight, flipHorizontal, flipVertical,
+            backgroundColor
+        );
+
+        Mono<Tuple3<BufferedImage, String, Integer>> convertedTuple = FlatMapUtil.flatMapMono(
+
+            () -> filePart,
+
+            fp -> Mono.fromCallable(() -> Files.createTempDirectory("imageUpload"))
+                .map(fld -> fld.resolve(fp.filename()))
+                .flatMap(path -> fp.transferTo(path).thenReturn(path))
+                .subscribeOn(Schedulers.boundedElastic()),
+
+            (fp, file) -> Mono.fromCallable(() -> ImageTransformUtil.makeSourceImage(file.toFile(), fp.filename()))
+                .subscribeOn(Schedulers.boundedElastic()),
+
+            (fp, file, srcTuple) -> Mono.just(CommonsUtil.nonNullValue(toFormat, ImagesFormatForResize.fromFileName(fp.filename())) == ImagesFormatForResize.PNG
+                ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB),
+
+            (fp, file, srcTuple, imageTargetType) -> Mono.fromCallable(() ->
+                    Tuples.of(ImageTransformUtil.transformImage(srcTuple.getT1(), imageTargetType, imageDetails), fp.filename(), imageTargetType))
+                .subscribeOn(Schedulers.boundedElastic())
+        ).contextWrite(Context.of(LogUtil.METHOD_NAME, "GenericResourceFileController.resizeImage"));
+
+        return FlatMapUtil.flatMapMono(
+                () -> convertedTuple,
+
+                tup -> {
+                    String targetFileName = tup.getT2();
+                    int imageTargetType = tup.getT3();
+                    String lowerName = targetFileName.toLowerCase();
+
+                    if ((imageTargetType == BufferedImage.TYPE_INT_ARGB && !lowerName.endsWith(".png")) ||
+                        (imageTargetType == BufferedImage.TYPE_INT_RGB && (!lowerName.endsWith(".jpg") && !lowerName.endsWith(".jpeg")))) {
+                        int index = targetFileName.lastIndexOf('.');
+                        targetFileName = (index > 0 ? targetFileName.substring(0, index) : targetFileName) +
+                            (lowerName.endsWith(".jpg") ? ".png" : ".jpg");
+                    }
+                    return Mono.just(targetFileName);
+                },
+
+                (tup, tFileName) -> {
+                    BufferedImage img = tup.getT1();
+                    int imageTargetType = tup.getT3();
+
+                    return Mono.fromCallable(() -> {
+                            ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+                            ImageIO.write(img, imageTargetType == BufferedImage.TYPE_INT_ARGB ? "png" : "jpg", byteStream);
+                            return byteStream;
+                        }).onErrorResume(ex -> this.msgService.throwMessage(msg -> new GenericException(HttpStatus.INTERNAL_SERVER_ERROR, msg),
+                            FilesMessageResourceService.IMAGE_TRANSFORM_ERROR, ex))
+                        .subscribeOn(Schedulers.boundedElastic());
+                },
+
+                (tup, targetFileName, byteStream) -> {
+                    HttpHeaders respHeaders = response.getHeaders();
+                    respHeaders.setContentDisposition(ContentDisposition.inline().filename(targetFileName).build());
+                    respHeaders.setContentType(tup.getT3() == BufferedImage.TYPE_INT_ARGB ? MediaType.IMAGE_PNG : MediaType.IMAGE_JPEG);
+                    ZeroCopyHttpOutputMessage zeroCopyResponse = (ZeroCopyHttpOutputMessage) response;
+                    respHeaders.setContentLength(byteStream.size());
+                    return zeroCopyResponse.writeWith(Mono.just(response.bufferFactory().wrap(byteStream.toByteArray())));
+                }
+            )
+            .contextWrite(Context.of(LogUtil.METHOD_NAME, "GenericResourceFileController.resizeImage (Part 2)"));
     }
 }

--- a/files/src/main/java/com/fincity/saas/files/enums/ImagesFormatForResize.java
+++ b/files/src/main/java/com/fincity/saas/files/enums/ImagesFormatForResize.java
@@ -1,0 +1,13 @@
+package com.fincity.saas.files.enums;
+
+public enum ImagesFormatForResize {
+
+    JPG,
+    JPEG,
+    PNG;
+
+    public static ImagesFormatForResize fromFileName(String fileName) {
+        String name = fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+        return ImagesFormatForResize.valueOf(name.toUpperCase());
+    }
+}

--- a/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
@@ -581,7 +581,7 @@ public abstract class AbstractFilesResourceService {
                         + pathParts.fileName);
             },
 
-            (hasPermission, tempDirectory, file) -> Mono.fromCallable(() -> this.makeSourceImage(file, pathParts)).subscribeOn(Schedulers.boundedElastic()),
+            (hasPermission, tempDirectory, file) -> Mono.fromCallable(() -> this.makeSourceImage(file, pathParts.fileName)).subscribeOn(Schedulers.boundedElastic()),
 
             (hasPermission, tempDirectory, file, sourceTuple) -> {
 
@@ -643,8 +643,8 @@ public abstract class AbstractFilesResourceService {
 
     }
 
-    private Tuple2<BufferedImage, Integer> makeSourceImage(File file,
-                                                           PathParts pathParts) throws IOException {
+    protected Tuple2<BufferedImage, Integer> makeSourceImage(File file,
+                                                             String fileName) throws IOException {
 
         ImageInputStream iis = ImageIO.createImageInputStream(file);
 
@@ -654,7 +654,7 @@ public abstract class AbstractFilesResourceService {
             ImageReader reader = imageReaders.next();
             reader.setInput(iis);
             return Tuples.of(reader.read(0),
-                pathParts.fileName.toLowerCase().endsWith("png") ? BufferedImage.TYPE_INT_ARGB
+                fileName.toLowerCase().endsWith("png") ? BufferedImage.TYPE_INT_ARGB
                     : BufferedImage.TYPE_INT_RGB);
         }
 

--- a/files/src/main/java/com/fincity/saas/files/service/SecuredFileResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/SecuredFileResourceService.java
@@ -283,6 +283,6 @@ public class SecuredFileResourceService extends AbstractFilesResourceService {
              sTuple, imgTuple, finalFile) ->
                 this.getFSService().createFileFromFile("SYSTEM",
                     "_userImages", finalFile.getName(), Paths.get(finalFile.getAbsolutePath()), true)
-        );
+        ).contextWrite(Context.of(LogUtil.METHOD_NAME, "SecuredFileResourceService.uploadUserImage"));
     }
 }

--- a/files/src/main/java/com/fincity/saas/files/service/StaticFileResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/StaticFileResourceService.java
@@ -4,6 +4,7 @@ import com.fincity.nocode.reactor.util.FlatMapUtil;
 import com.fincity.saas.commons.security.dto.Client;
 import com.fincity.saas.commons.security.feign.IFeignSecurityService;
 import com.fincity.saas.commons.security.util.SecurityContextUtil;
+import com.fincity.saas.commons.util.LogUtil;
 import com.fincity.saas.files.model.FileDetail;
 import com.fincity.saas.files.model.ImageDetails;
 import com.fincity.saas.files.util.ImageTransformUtil;
@@ -20,6 +21,7 @@ import com.fincity.saas.files.jooq.enums.FilesFileSystemType;
 import jakarta.annotation.PostConstruct;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
+import reactor.util.context.Context;
 import reactor.util.function.Tuples;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 
@@ -113,6 +115,6 @@ public class StaticFileResourceService extends AbstractFilesResourceService {
             (ca, cid, temp, file, sTuple, imgTuple, finalFile) ->
                 this.getFSService().createFileFromFile("SYSTEM",
                     "_clientImages", finalFile.getName(), Paths.get(finalFile.getAbsolutePath()), true)
-        );
+        ).contextWrite(Context.of(LogUtil.METHOD_NAME, "StaticFileResourceService.uploadClientImage"));
     }
 }

--- a/files/src/main/java/com/fincity/saas/files/util/ImageDetailsUtil.java
+++ b/files/src/main/java/com/fincity/saas/files/util/ImageDetailsUtil.java
@@ -1,0 +1,44 @@
+package com.fincity.saas.files.util;
+
+import com.fincity.saas.commons.util.BooleanUtil;
+import com.fincity.saas.files.model.ImageDetails;
+
+public class ImageDetailsUtil {
+
+    private ImageDetailsUtil() {
+    }
+
+
+    public static ImageDetails makeDetails(String width, String height, String rotation,
+                                           String cropAreaX, String cropAreaY,
+                                           String cropAreaWidth, String cropAreaHeight,
+                                           String flipHorizontal, String flipVertical, String backgroundColor) {
+        ImageDetails imageDetails = new ImageDetails()
+            .setFlipHorizontal(BooleanUtil.safeValueOf(flipHorizontal))
+            .setFlipVertical(BooleanUtil.safeValueOf(flipVertical))
+            .setBackgroundColor(backgroundColor);
+
+        if (width != null)
+            imageDetails.setWidth(Integer.valueOf(width));
+
+        if (height != null)
+            imageDetails.setHeight(Integer.valueOf(height));
+
+        if (rotation != null)
+            imageDetails.setRotation(Integer.valueOf(rotation));
+
+        if (cropAreaX != null)
+            imageDetails.setCropAreaX(Integer.valueOf(cropAreaX));
+
+        if (cropAreaY != null)
+            imageDetails.setCropAreaY(Integer.valueOf(cropAreaY));
+
+        if (cropAreaWidth != null)
+            imageDetails.setCropAreaWidth(Integer.valueOf(cropAreaWidth));
+
+        if (cropAreaHeight != null)
+            imageDetails.setCropAreaHeight(Integer.valueOf(cropAreaHeight));
+
+        return imageDetails;
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces several improvements and features for image handling and folder access control:

- **Image Transformation and Resizing:** Added a `resizeImage` API in `GenericResourceFileController` to support resizing, cropping, rotation, and format conversion. Shared image processing logic was refactored into `ImageTransformUtil`.
- **Reactive Context Logging:** Included method names in the reactive context of `uploadUserImage` and `uploadClientImage` for better traceability.
- **Folder Access Rules:** Updated `SecuredFileResourceService` to enforce tailored access rules for specific folders (e.g., `_userImages`, `_withInClient`). Also aligned image upload destination to `_userImages` instead of `_clientImages`.
- **Image Upload Logic Refactor:** Centralized image details creation in `ImageDetailsUtil` for better code reuse and added specific user and client upload endpoints via `GenericResourceFileController`.

