### PR TITLE
Feature/nclc2 195 o auth2 inhancement for google ads

### DIFF
--- a/core/src/main/resources/db/migration/V4__Alter Core Tokens.sql
+++ b/core/src/main/resources/db/migration/V4__Alter Core Tokens.sql
@@ -1,0 +1,6 @@
+use core;
+
+ALTER TABLE `core`.`core_tokens`
+    DROP CONSTRAINT `UK_CORE_TOKEN_STATE`;
+ALTER TABLE `core`.`core_tokens`
+    ADD CONSTRAINT `UK_CORE_TOKEN_STATE_TOKEN_TYPE` UNIQUE (`STATE`, `TOKEN_TYPE`);


### PR DESCRIPTION
updated refresh token support - google auth is having refresh token

- updated unique key constraint for state to be a unique key on combination of state and token_type