### PR TITLE
Add logging in `SecurityContextUtil` and optimize `AuthoritiesTokenEx…

### DIFF
--- a/commons-security/src/main/java/com/fincity/saas/commons/security/util/AuthoritiesTokenExtractor.java
+++ b/commons-security/src/main/java/com/fincity/saas/commons/security/util/AuthoritiesTokenExtractor.java
@@ -4,6 +4,9 @@ import com.fincity.nocode.kirun.engine.runtime.expression.tokenextractor.TokenVa
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
+import org.apache.logging.log4j.LogManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Collection;
@@ -12,8 +15,9 @@ import java.util.stream.Collectors;
 
 public class AuthoritiesTokenExtractor extends TokenValueExtractor {
 
+    private static final Logger log = LoggerFactory.getLogger(AuthoritiesTokenExtractor.class);
+
     private final Collection<? extends GrantedAuthority> authorities;
-    private Set<String> stringAuths;
 
     public AuthoritiesTokenExtractor(Collection<? extends GrantedAuthority> authorities) {
 
@@ -22,10 +26,7 @@ public class AuthoritiesTokenExtractor extends TokenValueExtractor {
 
     @Override
     protected JsonElement getValueInternal(String token) {
-        if (stringAuths == null) {
-            this.stringAuths = authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.toSet());
-        }
-        return new JsonPrimitive(this.stringAuths.contains(token.trim()));
+        return new JsonPrimitive(this.authorities.parallelStream().map(GrantedAuthority::getAuthority).anyMatch(e -> e.equals(token)));
     }
 
     @Override
@@ -37,7 +38,6 @@ public class AuthoritiesTokenExtractor extends TokenValueExtractor {
     public JsonElement getStore() {
 
         JsonArray arr = new JsonArray();
-        if (stringAuths == null) return arr;
 
         authorities.stream()
                 .map(GrantedAuthority::getAuthority)

--- a/commons-security/src/main/java/com/fincity/saas/commons/security/util/SecurityContextUtil.java
+++ b/commons-security/src/main/java/com/fincity/saas/commons/security/util/SecurityContextUtil.java
@@ -5,6 +5,8 @@ import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
@@ -20,6 +22,8 @@ import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
 public class SecurityContextUtil {
+
+    public static final Logger logger = LoggerFactory.getLogger(SecurityContextUtil.class);
 
     public static Mono<BigInteger> getUsersClientId() {
 
@@ -70,6 +74,9 @@ public class SecurityContextUtil {
 
     public static boolean hasAuthority(String authority, Collection<? extends GrantedAuthority> collection) {
 
+        logger.info("hasAuthority: Checking if authority {} exists", authority);
+        logger.info("hasAuthority: Checking in collection {} ", collection);
+
         if (authority == null || authority.isBlank())
             return true;
 
@@ -80,6 +87,8 @@ public class SecurityContextUtil {
         AuthoritiesTokenExtractor extractor = new AuthoritiesTokenExtractor(collection);
         JsonPrimitive jp = ev.evaluate(Map.of(extractor.getPrefix(), extractor))
                 .getAsJsonPrimitive();
+
+        logger.info("hasAuthority: Does the authority {} exists : {}", authority, jp);
         return jp.isBoolean() && jp.getAsBoolean();
     }
 


### PR DESCRIPTION
…tractor` logic

Introduced SLF4J-based logging in `SecurityContextUtil` for improved traceability of authority checks. Streamlined `AuthoritiesTokenExtractor` by utilizing a direct `Stream` operation to evaluate token existence, removing unnecessary state management.