### PR TITLE
feature/CN-534-lead-bucket-report

### DIFF
--- a/commons/src/main/java/com/fincity/saas/commons/gson/LocalDateTimeAdapter.java
+++ b/commons/src/main/java/com/fincity/saas/commons/gson/LocalDateTimeAdapter.java
@@ -1,7 +1,6 @@
 package com.fincity.saas.commons.gson;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 

--- a/commons2-jooq/src/main/java/com/modlix/saas/commons2/jooq/dao/AbstractDAO.java
+++ b/commons2-jooq/src/main/java/com/modlix/saas/commons2/jooq/dao/AbstractDAO.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -293,7 +294,7 @@ public abstract class AbstractDAO<R extends UpdatableRecord<R>, I extends Serial
         if (dt.isDate() || dt.isDateTime() || dt.isTime() || dt.isTimestamp()) {
 
             return value.equals("now") ? LocalDateTime.now()
-                    : LocalDateTime.ofInstant(Instant.ofEpochMilli(Long.valueOf(value.toString())), ZoneId.of("UTC"));
+                    : LocalDateTime.ofEpochSecond(Long.parseLong(value.toString()), 0, ZoneOffset.UTC);
         }
 
         return value;

--- a/commons2/src/main/java/com/modlix/saas/commons2/gson/LocalDateTimeAdapter.java
+++ b/commons2/src/main/java/com/modlix/saas/commons2/gson/LocalDateTimeAdapter.java
@@ -1,7 +1,6 @@
 package com.modlix.saas.commons2.gson;
 
 import java.io.IOException;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
@@ -31,6 +30,6 @@ public class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
         }
 
         String date = in.nextString();
-        return Instant.ofEpochSecond(0, Long.parseLong(date)).atZone(ZoneOffset.UTC).toLocalDateTime();
+        return LocalDateTime.ofEpochSecond(Long.parseLong(date), 0, ZoneOffset.UTC);
     }
 }


### PR DESCRIPTION
Refactored `LocalDateTimeAdapter` and `AbstractDAO` to replace `Instant` with `LocalDateTime.ofEpochSecond` for date conversions, ensuring consistency.