### PR TITLE
feature/CN-534-lead-bucket-report

### DIFF
--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/model/StatusEntityCount.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/model/StatusEntityCount.java
@@ -3,7 +3,6 @@ package com.fincity.saas.entity.processor.analytics.model;
 import com.fincity.saas.entity.processor.analytics.model.base.BaseStatusCount;
 import com.fincity.saas.entity.processor.model.common.IdAndValue;
 import java.io.Serial;
-import java.io.Serializable;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -15,7 +14,7 @@ import org.jooq.types.ULong;
 @Accessors(chain = true)
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-public class StatusEntityCount extends BaseStatusCount<StatusEntityCount> implements Serializable {
+public class StatusEntityCount extends BaseStatusCount<StatusEntityCount> {
 
     @Serial
     private static final long serialVersionUID = 6036698402832983531L;

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/model/base/BaseStatusCount.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/model/base/BaseStatusCount.java
@@ -1,5 +1,6 @@
 package com.fincity.saas.entity.processor.analytics.model.base;
 
+import com.fincity.saas.commons.util.IClassConvertor;
 import com.fincity.saas.entity.processor.analytics.model.CountPercentage;
 import com.fincity.saas.entity.processor.model.common.IdAndValue;
 import java.io.Serializable;
@@ -13,7 +14,7 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 @NoArgsConstructor
 @ToString(callSuper = true)
-public abstract class BaseStatusCount<T extends BaseStatusCount<T>> implements Serializable {
+public abstract class BaseStatusCount<T extends BaseStatusCount<T>> implements Serializable, IClassConvertor {
 
     private CountPercentage totalCount;
 

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/service/base/BaseAnalyticsService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/service/base/BaseAnalyticsService.java
@@ -8,6 +8,7 @@ import com.fincity.saas.commons.security.feign.IFeignSecurityService;
 import com.fincity.saas.commons.security.model.User;
 import com.fincity.saas.entity.processor.analytics.dao.base.BaseAnalyticsDAO;
 import com.fincity.saas.entity.processor.analytics.model.TicketBucketFilter;
+import com.fincity.saas.entity.processor.enums.IEntitySeries;
 import com.fincity.saas.entity.processor.model.common.IdAndValue;
 import com.fincity.saas.entity.processor.model.common.ProcessorAccess;
 import com.fincity.saas.entity.processor.service.ProcessorMessageResourceService;
@@ -23,7 +24,7 @@ import reactor.core.publisher.Mono;
 
 public abstract class BaseAnalyticsService<
                 R extends UpdatableRecord<R>, D extends AbstractDTO<ULong, ULong>, O extends BaseAnalyticsDAO<R, D>>
-        extends AbstractJOOQDataService<R, ULong, D, O> implements IProcessorAccessService {
+        extends AbstractJOOQDataService<R, ULong, D, O> implements IProcessorAccessService, IEntitySeries {
 
     @Getter
     protected IFeignSecurityService securityService;


### PR DESCRIPTION
1. Added `getTicketPerClientIdStatusCount` in `TicketBucketService` with support for client-stage grouping
2. Enhanced `PartnerService` to fill partner ticket details with lead bucket reporting logic. 
3. Refactored `BaseStatusCount` to implement `IClassConvertor`.