### PR TITLE
feature/CN-534-lead-bucket-report

### DIFF
--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/model/base/BaseStatusCount.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/model/base/BaseStatusCount.java
@@ -20,6 +20,8 @@ public abstract class BaseStatusCount<T extends BaseStatusCount<T>> implements S
 
     private List<IdAndValue<String, CountPercentage>> perCount;
 
+    public abstract String getName();
+
     public T setTotalCount(CountPercentage totalCount) {
         this.totalCount = totalCount;
         return (T) this;

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/util/ReportUtil.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/util/ReportUtil.java
@@ -7,10 +7,12 @@ import com.fincity.saas.entity.processor.analytics.model.DateStatusCount;
 import com.fincity.saas.entity.processor.analytics.model.PerDateCount;
 import com.fincity.saas.entity.processor.analytics.model.StatusEntityCount;
 import com.fincity.saas.entity.processor.analytics.model.StatusNameCount;
+import com.fincity.saas.entity.processor.analytics.model.base.BaseStatusCount;
 import com.fincity.saas.entity.processor.analytics.model.base.PerCount;
 import com.fincity.saas.entity.processor.model.common.IdAndValue;
 import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -19,6 +21,7 @@ import java.util.NavigableMap;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
 import org.jooq.types.ULong;
 import reactor.core.publisher.Flux;
@@ -60,26 +63,80 @@ public class ReportUtil {
                     .distinct()
                     .toList();
 
+        Set<String> groupedValue = includeZero
+                ? perDateCountList.stream().map(PerDateCount::getGroupedValue).collect(Collectors.toSet())
+                : Set.of();
+
         List<IdAndValue<ULong, String>> finalRequired = requiredValueList;
         return Flux.fromIterable(datePairMap.entrySet())
                 .filter(entry -> includeZero || !entry.getValue().isEmpty())
                 .publishOn(Schedulers.boundedElastic())
                 .flatMap(entry -> {
-                    List<PerDateCount> dateGroupedList = entry.getValue();
+                    String mapValue = finalRequired.getFirst().getValue();
+
+                    List<PerDateCount> dateGroupedListWithZeros = includeZero
+                            ? Stream.concat(
+                                            entry.getValue().stream(),
+                                            groupedValue.stream().map(value -> new PerDateCount()
+                                                    .setCount(0L)
+                                                    .setDate(entry.getKey().getFirst())
+                                                    .setGroupedValue(value)
+                                                    .setMapValue(mapValue)))
+                                    .toList()
+                            : entry.getValue();
 
                     return toStatusCountsGroupedValue(
-                                    dateGroupedList,
+                                    dateGroupedListWithZeros,
                                     finalRequired,
                                     includeZero,
                                     includePercentage,
                                     includeTotal,
                                     includeNone)
                             .collectList()
-                            .map(statusCounts -> new DateStatusCount()
-                                    .setDatePair(entry.getKey())
-                                    .setStatusCount(statusCounts));
+                            .map(statusCounts -> {
+                                List<StatusNameCount> processed =
+                                        includePercentage ? addPercentage(statusCounts, includeTotal) : statusCounts;
+                                processed.sort(getComparator(includeTotal));
+                                return new DateStatusCount()
+                                        .setDatePair(entry.getKey())
+                                        .setStatusCount(processed);
+                            });
                 })
                 .contextWrite(Context.of(LogUtil.METHOD_NAME, "ReportUtil.toDateStatusCounts"));
+    }
+
+    private static Comparator<StatusNameCount> getComparator(boolean includeTotal) {
+        if (includeTotal)
+            return Comparator.comparing((StatusNameCount status) -> TOTAL.equalsIgnoreCase(status.getName()) ? 0 : 1)
+                    .thenComparing(StatusNameCount::getName);
+        return Comparator.comparing(StatusNameCount::getName);
+    }
+
+    private static <T extends BaseStatusCount<T>> List<T> addPercentage(List<T> statusCountList, boolean includeTotal) {
+
+        if (statusCountList.isEmpty()) return statusCountList;
+
+        T totalEntry = includeTotal
+                ? statusCountList.stream()
+                        .filter(statusCount -> TOTAL.equalsIgnoreCase(statusCount.getName()))
+                        .findFirst()
+                        .orElse(null)
+                : null;
+
+        if (includeTotal && totalEntry == null) return statusCountList;
+
+        long total = (totalEntry != null)
+                ? totalEntry.getTotalCount().getCount().longValue()
+                : statusCountList.stream()
+                        .mapToLong(statusCount ->
+                                statusCount.getTotalCount().getCount().longValue())
+                        .sum();
+
+        statusCountList.forEach(statusCount -> statusCount.getTotalCount().recalculatePercentage(total));
+
+        if (totalEntry != null) totalEntry.getTotalCount().setPercentage(100.0);
+
+        return statusCountList;
     }
 
     public static <T extends PerCount<T>> Flux<StatusEntityCount> toStatusCountsGroupedIds(
@@ -314,9 +371,8 @@ public class ReportUtil {
             String valueKey = initialValue.getId();
             Long count = values.getOrDefault(valueKey, 0L);
 
-            CountPercentage cp = includePercentage && totalCount > 0
-                    ? CountPercentage.of(count, totalCount)
-                    : CountPercentage.withCount(count);
+            CountPercentage cp =
+                    includePercentage ? CountPercentage.of(count, totalCount) : CountPercentage.withCount(count);
 
             valueCounts.add(IdAndValue.of(valueKey, cp));
         }


### PR DESCRIPTION
1. Enhanced `ReportUtil` to handle zero-value grouping in status counts,
2. added percentage calculations with optional total inclusion, 
3. introduced sorting logic for status names. 
4. Updated `BaseStatusCount` to include an abstract `getName`.