### PR TITLE
feature/CN-634-enable-whats-app-product-assignment-functionality

### DIFF
--- a/message/src/main/java/com/fincity/saas/message/service/message/provider/AbstractMessageService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/message/provider/AbstractMessageService.java
@@ -147,6 +147,6 @@ public abstract class AbstractMessageService<
     }
 
     private String buildUrl(String baseUrl, String appCode, String clientCode, String provider) {
-        return baseUrl + "/" + appCode + "/" + clientCode + PAGE_URI + WEBHOOK_URI + provider;
+        return baseUrl + "/" + appCode + "/" + clientCode + PAGE_URI + WEBHOOK_URI + "/" + provider;
     }
 }

--- a/message/src/main/java/com/fincity/saas/message/service/message/provider/AbstractMessageService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/message/provider/AbstractMessageService.java
@@ -121,11 +121,11 @@ public abstract class AbstractMessageService<
     }
 
     protected Mono<String> getWebhookUrl(String appCode, String clientCode) {
-        return buildWebhookUrl(appCode, clientCode != null ? clientCode : SYSTEM);
+        return this.buildWebhookUrl(appCode, clientCode != null ? clientCode : SYSTEM);
     }
 
     protected Mono<String> getWebhookAppUrl(String appCode) {
-        return buildWebhookUrl(appCode, SYSTEM);
+        return this.buildWebhookUrl(appCode, SYSTEM);
     }
 
     protected Mono<IdAndValue<ULong, PhoneNumber>> getUserIdAndPhone(ULong userId) {


### PR DESCRIPTION
Fixed URL construction in `buildUrl` method by adding a missing slash before the provider parameter.