### PR TITLE
feature/CN-634-enable-whats-app-product-assignment-functionality

### DIFF
--- a/message/src/main/java/com/fincity/saas/message/model/message/whatsapp/business/SubscribedApp.java
+++ b/message/src/main/java/com/fincity/saas/message/model/message/whatsapp/business/SubscribedApp.java
@@ -18,6 +18,6 @@ public final class SubscribedApp implements Serializable {
     @JsonProperty("whatsapp_business_api_data")
     private BusinessApiData businessApiData;
 
-    @JsonProperty("override_call_back_url")
+    @JsonProperty("override_callback_uri")
     private String overrideCallBackUrl;
 }

--- a/message/src/main/java/com/fincity/saas/message/service/message/provider/AbstractMessageService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/message/provider/AbstractMessageService.java
@@ -30,7 +30,7 @@ public abstract class AbstractMessageService<
                 R extends UpdatableRecord<R>, D extends BaseUpdatableDto<D>, O extends BaseProviderDAO<R, D>>
         extends BaseUpdatableService<R, D, O> implements IMessageService<D> {
 
-    private static final String WEBHOOK_URI = "/api/message/webhook";
+    private static final String WEBHOOK_URI = "/api/message/webhooks";
 
     private static final String SYSTEM = "SYSTEM";
 


### PR DESCRIPTION
Updated `WEBHOOK_URI` path and renamed `overrideCallBackUrl` to `overrideCallbackUri` for consistency.