### PR TITLE
feat(message): integrate exotel real-time webhook status updates

### DIFF
--- a/message/src/main/java/com/fincity/saas/message/controller/ServerSentEventController.java
+++ b/message/src/main/java/com/fincity/saas/message/controller/ServerSentEventController.java
@@ -2,89 +2,104 @@ package com.fincity.saas.message.controller;
 
 import com.fincity.saas.message.model.event.MessageServerEvent;
 import com.fincity.saas.message.service.call.event.CallEventService;
+import com.fincity.saas.message.service.message.event.MessageEventService;
 import java.math.BigInteger;
-import org.springframework.beans.factory.annotation.Autowired;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 
 @RestController
 @RequestMapping("/api/message/events")
+@RequiredArgsConstructor
 public class ServerSentEventController {
 
-    private final CallEventService eventService;
+    private final CallEventService callEventService;
+    private final MessageEventService messageEventService;
 
-    @Autowired
-    public ServerSentEventController(CallEventService eventService) {
-        this.eventService = eventService;
+    private static final String INIT_EVENT = "init";
+
+    private static final Set<String> DEFAULT_CALL_EVENTS = Set.of(
+            CallEventService.EVENT_TYPE_MAKE_CALL,
+            CallEventService.EVENT_TYPE_INCOMING_CALL,
+            CallEventService.EVENT_TYPE_CALL_STATUS,
+            CallEventService.EVENT_TYPE_PASSTHRU_CALLBACK
+    );
+
+    private static final Set<String> DEFAULT_MESSAGE_EVENTS = Set.of(
+            MessageEventService.EVENT_TYPE_MESSAGE,
+            MessageEventService.EVENT_TYPE_MESSAGE_STATUS,
+            MessageEventService.EVENT_TYPE_INCOMING_MESSAGE
+    );
+
+    // ─── Filter Helpers ──────────────────────────────────────────────────────────
+
+    private boolean isMetaEvent(ServerSentEvent<MessageServerEvent> sse) {
+        return INIT_EVENT.equals(sse.event()) || sse.comment() != null;
     }
 
-    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<MessageServerEvent> getEventStream(
-            @RequestParam("appCode") String appCode,
-            @RequestParam("clientCode") String clientCode,
-            @RequestParam("userId") BigInteger userId) {
+    private Flux<ServerSentEvent<MessageServerEvent>> filterByEventTypes(
+            Flux<ServerSentEvent<MessageServerEvent>> stream,
+            Set<String> allowedEvents) {
 
-        return eventService.getEventStream(appCode, clientCode, userId);
-    }
+        return stream.filter(sse -> {
+            if (isMetaEvent(sse))
+                return true;
 
-    @GetMapping(value = "/call/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<MessageServerEvent> getCallEventStream(
-            @RequestParam("appCode") String appCode,
-            @RequestParam("clientCode") String clientCode,
-            @RequestParam("userId") BigInteger userId) {
-
-        return eventService.getEventStream(appCode, clientCode, userId).filter(event -> {
-            String eventType = event.getEventType();
-            return eventType != null
-                    && (eventType.equals(CallEventService.EVENT_TYPE_MAKE_CALL)
-                            || eventType.equals(CallEventService.EVENT_TYPE_INCOMING_CALL)
-                            || eventType.equals(CallEventService.EVENT_TYPE_CALL_STATUS)
-                            || eventType.equals(CallEventService.EVENT_TYPE_PASSTHRU_CALLBACK));
+            MessageServerEvent event = sse.data();
+            return event != null && allowedEvents.contains(event.getEventType());
         });
     }
 
-    @GetMapping(value = "/call/makeCall/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<MessageServerEvent> getMakeCallEventStream(
+    // ─── Generic Raw Stream (no filters) ───────────────────────────────────────
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<MessageServerEvent>> getEventStream(
             @RequestParam("appCode") String appCode,
             @RequestParam("clientCode") String clientCode,
             @RequestParam("userId") BigInteger userId) {
-
-        return eventService
-                .getEventStream(appCode, clientCode, userId)
-                .filter(event -> CallEventService.EVENT_TYPE_MAKE_CALL.equals(event.getEventType()));
+        return callEventService.getEventStream(appCode, clientCode, userId);
     }
 
-    @GetMapping(value = "/call/incomingCall/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<MessageServerEvent> getIncomingCallEventStream(
+    // ─── Consolidated Call Stream ──────────────────────────────────────────────
+
+    @GetMapping(value = "/call/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<MessageServerEvent>> getCallEventStream(
             @RequestParam("appCode") String appCode,
             @RequestParam("clientCode") String clientCode,
-            @RequestParam("userId") BigInteger userId) {
+            @RequestParam("userId") BigInteger userId,
+            @RequestParam(value = "types", required = false) Set<String> types) {
 
-        return eventService
-                .getEventStream(appCode, clientCode, userId)
-                .filter(event -> CallEventService.EVENT_TYPE_INCOMING_CALL.equals(event.getEventType()));
+        if (types != null && !types.isEmpty()) {
+            if (!DEFAULT_CALL_EVENTS.containsAll(types)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid event types: " + types);
+            }
+            return filterByEventTypes(callEventService.getEventStream(appCode, clientCode, userId), types);
+        }
+
+        return filterByEventTypes(callEventService.getEventStream(appCode, clientCode, userId), DEFAULT_CALL_EVENTS);
     }
 
-    @GetMapping(value = "/call/callStatus/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<MessageServerEvent> getCallStatusEventStream(
+    // ─── Consolidated Message Stream ───────────────────────────────────────────
+
+    @GetMapping(value = "/message/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<MessageServerEvent>> getMessageEventStream(
             @RequestParam("appCode") String appCode,
             @RequestParam("clientCode") String clientCode,
-            @RequestParam("userId") BigInteger userId) {
+            @RequestParam("userId") BigInteger userId,
+            @RequestParam(value = "types", required = false) Set<String> types) {
 
-        return eventService
-                .getEventStream(appCode, clientCode, userId)
-                .filter(event -> CallEventService.EVENT_TYPE_CALL_STATUS.equals(event.getEventType()));
-    }
+        if (types != null && !types.isEmpty()) {
+            if (!DEFAULT_MESSAGE_EVENTS.containsAll(types)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid event types: " + types);
+            }
+            return filterByEventTypes(messageEventService.getEventStream(appCode, clientCode, userId), types);
+        }
 
-    @GetMapping(value = "/call/passthruCallback/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public Flux<MessageServerEvent> getPassthruCallbackEventStream(
-            @RequestParam("appCode") String appCode,
-            @RequestParam("clientCode") String clientCode,
-            @RequestParam("userId") BigInteger userId) {
-
-        return eventService
-                .getEventStream(appCode, clientCode, userId)
-                .filter(event -> CallEventService.EVENT_TYPE_PASSTHRU_CALLBACK.equals(event.getEventType()));
+        return filterByEventTypes(messageEventService.getEventStream(appCode, clientCode, userId), DEFAULT_MESSAGE_EVENTS);
     }
 }

--- a/message/src/main/java/com/fincity/saas/message/dto/call/provider/exotel/ExotelCall.java
+++ b/message/src/main/java/com/fincity/saas/message/dto/call/provider/exotel/ExotelCall.java
@@ -181,7 +181,9 @@ public class ExotelCall extends BaseUpdatableDto<ExotelCall> {
 
         if (this.sid == null) SetterUtil.setIfPresent(callback.getCallSid(), this::setSid);
 
-        SetterUtil.setIfPresent(callback.getCallStatus(), this::setExotelCallStatus);
+        if (callback.getCallStatus() != null) {
+            this.setExotelCallStatus(getStatusByDisplayName(callback.getCallStatus()));
+        }
         SetterUtil.setIfPresent(callback.getRecordingUrl(), this::setRecordingUrl);
         SetterUtil.setIfPresent(callback.getDirection(), this::setDirection);
 
@@ -199,6 +201,25 @@ public class ExotelCall extends BaseUpdatableDto<ExotelCall> {
 
         SetterUtil.setIfPresent(callback.getOutgoingPhoneNumber(), this::setCallerId);
 
+        if (this.exotelConnectAppletRequest == null) {
+            this.exotelConnectAppletRequest = new ExotelConnectAppletRequest();
+        }
+        if (callback.getEventType() != null) {
+            this.exotelConnectAppletRequest.setDialCallStatus(callback.getEventType());
+        } else if (callback.getDialCallStatus() != null) {
+            this.exotelConnectAppletRequest.setDialCallStatus(callback.getDialCallStatus());
+        }
+
         return this;
+    }
+
+    private static ExotelCallStatus getStatusByDisplayName(String displayName) {
+        if (displayName == null) return null;
+        for (ExotelCallStatus s : ExotelCallStatus.values()) {
+            if (s.getDisplayName().equalsIgnoreCase(displayName) || s.name().equalsIgnoreCase(displayName)) {
+                return s;
+            }
+        }
+        return null;
     }
 }

--- a/message/src/main/java/com/fincity/saas/message/model/request/call/provider/exotel/ExotelPassThruCallback.java
+++ b/message/src/main/java/com/fincity/saas/message/model/request/call/provider/exotel/ExotelPassThruCallback.java
@@ -2,7 +2,6 @@ package com.fincity.saas.message.model.request.call.provider.exotel;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fincity.saas.message.enums.call.provider.exotel.ExotelCallStatus;
 import com.fincity.saas.message.util.SetterUtil;
 import java.io.Serial;
 import java.io.Serializable;
@@ -32,7 +31,7 @@ public class ExotelPassThruCallback implements Serializable {
     private String callTo;
 
     @JsonProperty("CallStatus")
-    private ExotelCallStatus callStatus;
+    private String callStatus;
 
     @JsonProperty("Direction")
     private String direction;
@@ -65,7 +64,13 @@ public class ExotelPassThruCallback implements Serializable {
     private String currentTime;
 
     @JsonProperty("DialCallStatus")
-    private ExotelCallStatus dialCallStatus;
+    private String dialCallStatus;
+
+    @JsonProperty("Status")
+    private String status;
+
+    @JsonProperty("EventType")
+    private String eventType;
 
     @JsonProperty("Legs")
     private List<Map<String, Object>> legs;
@@ -83,6 +88,9 @@ public class ExotelPassThruCallback implements Serializable {
     private String outgoingPhoneNumber;
 
     public static ExotelPassThruCallback of(MultiValueMap<String, String> formData) {
+        if (formData == null || formData.isEmpty())
+            return new ExotelPassThruCallback();
+
         ExotelPassThruCallback callback = new ExotelPassThruCallback();
 
         SetterUtil.setIfPresent(formData, "CallSid", callback::setCallSid);
@@ -100,27 +108,18 @@ public class ExotelPassThruCallback implements Serializable {
         SetterUtil.setIfPresent(formData, "CustomField", callback::setCustomField);
         SetterUtil.setIfPresent(formData, "RecordingUrl", callback::setRecordingUrl);
         SetterUtil.setIfPresent(formData, "OutgoingPhoneNumber", callback::setOutgoingPhoneNumber);
+        SetterUtil.setIfPresent(formData, "CallStatus", callback::setCallStatus);
+        SetterUtil.setIfPresent(formData, "DialCallStatus", callback::setDialCallStatus);
+        SetterUtil.setIfPresent(formData, "Status", callback::setStatus);
+        SetterUtil.setIfPresent(formData, "EventType", callback::setEventType);
 
         SetterUtil.parseLongIfPresent(formData, "DialCallDuration", callback::setDialCallDuration);
-
-        SetterUtil.parseEnumIfPresent(
-                formData,
-                "CallStatus",
-                ExotelCallStatus.class,
-                status -> status.getDisplayName().equals(formData.getFirst("CallStatus")),
-                callback::setCallStatus);
-
-        SetterUtil.parseEnumIfPresent(
-                formData,
-                "DialCallStatus",
-                ExotelCallStatus.class,
-                status -> status.getDisplayName().equals(formData.getFirst("DialCallStatus")),
-                callback::setDialCallStatus);
 
         String digits = formData.getFirst("digits");
         if (digits != null) {
             digits = digits.trim();
-            if (digits.startsWith("\"") && digits.endsWith("\"")) digits = digits.substring(1, digits.length() - 1);
+            if (digits.startsWith("\"") && digits.endsWith("\""))
+                digits = digits.substring(1, digits.length() - 1);
             callback.setDigits(digits);
         }
 

--- a/message/src/main/java/com/fincity/saas/message/service/call/event/CallEventService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/call/event/CallEventService.java
@@ -12,10 +12,11 @@ import reactor.core.publisher.Mono;
 @Service
 public class CallEventService extends AbstractServerSentEventService {
 
-    public static final String EVENT_TYPE_MAKE_CALL = "MAKE_CALL";
-    public static final String EVENT_TYPE_INCOMING_CALL = "INCOMING_CALL";
-    public static final String EVENT_TYPE_CALL_STATUS = "CALL_STATUS";
-    public static final String EVENT_TYPE_PASSTHRU_CALLBACK = "PASSTHRU_CALLBACK";
+    public static final String EVENT_TYPE_MAKE_CALL = "makeCall";
+    public static final String EVENT_TYPE_INCOMING_CALL = "incomingCall";
+    public static final String EVENT_TYPE_CALL_STATUS = "callStatus";
+    public static final String EVENT_TYPE_PASSTHRU_CALLBACK = "passthruCallback";
+
 
     public Mono<Void> sendCallEvent(MessageServerEvent event) {
         if (event == null || event.getAppCode() == null || event.getClientCode() == null)

--- a/message/src/main/java/com/fincity/saas/message/service/call/provider/exotel/ExotelCallService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/call/provider/exotel/ExotelCallService.java
@@ -302,6 +302,10 @@ public class ExotelCallService extends AbstractCallProviderService<MessageExotel
                 super.getConnectionDetail(
                         details, ExotelConnectAppletResponse.Fields.maxConversationDuration, Long.class),
                 response::setMaxConversationDuration);
+        SetterUtil.setIfPresent(
+                super.getConnectionDetail(
+                        details, ExotelConnectAppletResponse.Fields.dialPassthruEventUrl, String.class),
+                response::setDialPassthruEventUrl);
 
         ExotelConnectAppletResponse.ParallelRinging parallelRinging = new ExotelConnectAppletResponse.ParallelRinging();
 

--- a/message/src/main/java/com/fincity/saas/message/service/event/AbstractServerSentEventService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/event/AbstractServerSentEventService.java
@@ -2,10 +2,13 @@ package com.fincity.saas.message.service.event;
 
 import com.fincity.saas.message.model.event.MessageServerEvent;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.codec.ServerSentEvent;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
@@ -15,20 +18,58 @@ public abstract class AbstractServerSentEventService {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractServerSentEventService.class);
 
+    private static final String INIT_EVENT = "init";
+    private static final String KEEPALIVE_COMMENT = "keepalive";
+
     protected final Map<String, Many<MessageServerEvent>> eventSinks = new ConcurrentHashMap<>();
 
-    public Flux<MessageServerEvent> getEventStream(String appCode, String clientCode, BigInteger userId) {
-        return this.getSink(appCode, clientCode, userId).asFlux();
+    public Flux<ServerSentEvent<MessageServerEvent>> getEventStream(String appCode, String clientCode,
+            BigInteger userId) {
+        String key = getEventSinkKey(appCode, clientCode, userId);
+
+        Flux<ServerSentEvent<MessageServerEvent>> eventStream = this.getSink(appCode, clientCode, userId).asFlux()
+                .map(this::buildEvent)
+                .doFinally(signal -> {
+                    eventSinks.computeIfPresent(key, (k, existingSink) -> {
+                        if (existingSink.currentSubscriberCount() == 0) {
+                            return null;
+                        }
+                        return existingSink;
+                    });
+                });
+
+        Flux<ServerSentEvent<MessageServerEvent>> heartbeat = Flux.interval(Duration.ofSeconds(25))
+                .map(tick -> buildHeartbeat());
+
+        return Flux.concat(Flux.just(buildEvent(MessageServerEvent.of(INIT_EVENT))), Flux.merge(eventStream, heartbeat));
+    }
+
+    private ServerSentEvent<MessageServerEvent> buildEvent(MessageServerEvent event) {
+        return ServerSentEvent.<MessageServerEvent>builder()
+                .id(event.getId() != null ? event.getId() : UUID.randomUUID().toString())
+                .event(event.getEventType())
+                .data(event)
+                .build();
+    }
+
+    private ServerSentEvent<MessageServerEvent> buildHeartbeat() {
+        return ServerSentEvent.<MessageServerEvent>builder()
+                .comment(KEEPALIVE_COMMENT)
+                .build();
+    }
+
+    private void validateEvent(MessageServerEvent event) {
+        if (event == null || event.getAppCode() == null || event.getClientCode() == null) {
+            throw new IllegalArgumentException("Event, appCode, and clientCode cannot be null");
+        }
     }
 
     public Mono<Void> sendEvent(MessageServerEvent event) {
-        if (event == null || event.getAppCode() == null || event.getClientCode() == null)
-            return Mono.error(new IllegalArgumentException("Event, appCode, and clientCode cannot be null"));
-
-        Many<MessageServerEvent> sink = getSink(event.getAppCode(), event.getClientCode(), event.getUserId());
-
         return Mono.fromRunnable(() -> {
-            logger.debug("Sending event: {}", event);
+            validateEvent(event);
+
+            Many<MessageServerEvent> sink = getSink(event.getAppCode(), event.getClientCode(), event.getUserId());
+
             Sinks.EmitResult result = sink.tryEmitNext(event);
             if (result.isFailure()) logger.error("Failed to emit event: {}", result);
         });

--- a/message/src/main/java/com/fincity/saas/message/service/message/event/MessageEventService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/message/event/MessageEventService.java
@@ -12,12 +12,12 @@ import reactor.util.context.Context;
 @Service
 public class MessageEventService extends AbstractServerSentEventService {
 
-    private static final String MESSAGE_EVENT_TYPE = "MESSAGE";
-    private static final String MESSAGE_STATUS_EVENT_TYPE = "MESSAGE_STATUS";
-    private static final String INCOMING_MESSAGE_EVENT_TYPE = "INCOMING_MESSAGE";
+    public static final String EVENT_TYPE_MESSAGE = "message";
+    public static final String EVENT_TYPE_MESSAGE_STATUS = "messageStatus";
+    public static final String EVENT_TYPE_INCOMING_MESSAGE = "incomingMessage";
 
     public Mono<Void> sendMessageEvent(MessageAccess access, WhatsappMessage message) {
-        MessageServerEvent event = MessageServerEvent.of(MESSAGE_EVENT_TYPE, message.toMap())
+        MessageServerEvent event = MessageServerEvent.of(EVENT_TYPE_MESSAGE, message.toMap())
                 .setAppCode(access.getAppCode())
                 .setClientCode(access.getClientCode())
                 .setUserId(access.getUserId() != null ? access.getUserId().toBigInteger() : null);
@@ -27,7 +27,7 @@ public class MessageEventService extends AbstractServerSentEventService {
     }
 
     public Mono<Void> sendMessageStatusEvent(MessageAccess access, WhatsappMessage message) {
-        MessageServerEvent event = MessageServerEvent.of(MESSAGE_STATUS_EVENT_TYPE, message.toMap())
+        MessageServerEvent event = MessageServerEvent.of(EVENT_TYPE_MESSAGE_STATUS, message.toMap())
                 .setAppCode(access.getAppCode())
                 .setClientCode(access.getClientCode())
                 .setUserId(access.getUserId() != null ? access.getUserId().toBigInteger() : null);
@@ -37,7 +37,7 @@ public class MessageEventService extends AbstractServerSentEventService {
     }
 
     public Mono<Void> sendIncomingMessageEvent(MessageAccess access, WhatsappMessage message) {
-        MessageServerEvent event = MessageServerEvent.of(INCOMING_MESSAGE_EVENT_TYPE, message.toMap())
+        MessageServerEvent event = MessageServerEvent.of(EVENT_TYPE_INCOMING_MESSAGE, message.toMap())
                 .setAppCode(access.getAppCode())
                 .setClientCode(access.getClientCode())
                 .setUserId(access.getUserId() != null ? access.getUserId().toBigInteger() : null);


### PR DESCRIPTION
- Map 'dialPassthruEventUrl' from Exotel connection details to dynamically pass the callback endpoint back to Exotel during /connect.
- Change 'CallStatus' and 'DialCallStatus' fields in ExotelPassThruCallback to String type to support intermediate status values (like "ringing", "answered", etc.) without parsing failures.
- Map and capture Exotel Connect Applet parameters 'Status' and 'EventType' inside ExotelPassThruCallback.
- Save the current call stage into 'exotelConnectAppletRequest.dialCallStatus' during update steps to stream live status events (Ringing, Answered, completed) to the UI in real-time.