### PR TITLE
fix(analytics): resolve deal double-counting, template fallback, and …

### DIFF
--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/dao/TicketBucketDAO.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/dao/TicketBucketDAO.java
@@ -1249,40 +1249,106 @@ public class TicketBucketDAO extends BaseAnalyticsDAO<EntityProcessorTicketsReco
     }
 
     public Flux<ULong> getDistinctClientIdsForDateRange(ProcessorAccess access, TicketBucketFilter ticketBucketFilter) {
+        if (ticketBucketFilter != null && ticketBucketFilter.isOnlyCurrentStageStatus()) {
+            return FlatMapUtil.flatMapFlux(
+                    () -> super.createBucketConditions(access, ticketBucketFilter).flux(),
+                    abstractCondition -> super.filter(abstractCondition).flux(),
+                    (abstractCondition, conditions) -> Flux.from(this.dslContext
+                                    .selectDistinct(ENTITY_PROCESSOR_TICKETS.CLIENT_ID)
+                                    .from(this.table)
+                                    .where(conditions)
+                                    .and(ENTITY_PROCESSOR_TICKETS.CLIENT_ID.isNotNull()))
+                            .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.CLIENT_ID)));
+        }
+
         return FlatMapUtil.flatMapFlux(
-                () -> super.createBucketConditions(access, ticketBucketFilter).flux(),
+                () -> this.createTicketBucketConditionsWithoutDate(access, ticketBucketFilter).flux(),
                 abstractCondition -> super.filter(abstractCondition).flux(),
-                (abstractCondition, conditions) -> Flux.from(this.dslContext
-                                .selectDistinct(ENTITY_PROCESSOR_TICKETS.CLIENT_ID)
-                                .from(this.table)
-                                .where(conditions)
-                                .and(ENTITY_PROCESSOR_TICKETS.CLIENT_ID.isNotNull()))
-                        .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.CLIENT_ID)));
+                (abstractCondition, conditions) -> {
+                    Condition activityCondition = this.buildActivityCondition(
+                            ticketBucketFilter.getStartDate(),
+                            ticketBucketFilter.getEndDate(),
+                            ticketBucketFilter.getStageIds());
+
+                    return Flux.from(this.dslContext
+                                    .selectDistinct(ENTITY_PROCESSOR_TICKETS.CLIENT_ID)
+                                    .from(this.table)
+                                    .join(ENTITY_PROCESSOR_ACTIVITIES)
+                                    .on(this.idField.eq(ENTITY_PROCESSOR_ACTIVITIES.TICKET_ID))
+                                    .where(conditions)
+                                    .and(activityCondition)
+                                    .and(ENTITY_PROCESSOR_TICKETS.CLIENT_ID.isNotNull()))
+                            .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.CLIENT_ID));
+                });
     }
 
     public Flux<ULong> getDistinctProductIdsForDateRange(ProcessorAccess access, TicketBucketFilter ticketBucketFilter) {
+        if (ticketBucketFilter != null && ticketBucketFilter.isOnlyCurrentStageStatus()) {
+            return FlatMapUtil.flatMapFlux(
+                    () -> super.createBucketConditions(access, ticketBucketFilter).flux(),
+                    abstractCondition -> super.filter(abstractCondition).flux(),
+                    (abstractCondition, conditions) -> Flux.from(this.dslContext
+                                    .selectDistinct(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID)
+                                    .from(this.table)
+                                    .where(conditions)
+                                    .and(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID.isNotNull()))
+                            .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID)));
+        }
+
         return FlatMapUtil.flatMapFlux(
-                () -> super.createBucketConditions(access, ticketBucketFilter).flux(),
+                () -> this.createTicketBucketConditionsWithoutDate(access, ticketBucketFilter).flux(),
                 abstractCondition -> super.filter(abstractCondition).flux(),
-                (abstractCondition, conditions) -> Flux.from(this.dslContext
-                                .selectDistinct(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID)
-                                .from(this.table)
-                                .where(conditions)
-                                .and(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID.isNotNull()))
-                        .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID)));
+                (abstractCondition, conditions) -> {
+                    Condition activityCondition = this.buildActivityCondition(
+                            ticketBucketFilter.getStartDate(),
+                            ticketBucketFilter.getEndDate(),
+                            ticketBucketFilter.getStageIds());
+
+                    return Flux.from(this.dslContext
+                                    .selectDistinct(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID)
+                                    .from(this.table)
+                                    .join(ENTITY_PROCESSOR_ACTIVITIES)
+                                    .on(this.idField.eq(ENTITY_PROCESSOR_ACTIVITIES.TICKET_ID))
+                                    .where(conditions)
+                                    .and(activityCondition)
+                                    .and(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID.isNotNull()))
+                            .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.PRODUCT_ID));
+                });
     }
 
     public Flux<ULong> getDistinctAssignedUserIdsForDateRange(
             ProcessorAccess access, TicketBucketFilter ticketBucketFilter) {
+        if (ticketBucketFilter != null && ticketBucketFilter.isOnlyCurrentStageStatus()) {
+            return FlatMapUtil.flatMapFlux(
+                    () -> super.createBucketConditions(access, ticketBucketFilter).flux(),
+                    abstractCondition -> super.filter(abstractCondition).flux(),
+                    (abstractCondition, conditions) -> Flux.from(this.dslContext
+                                    .selectDistinct(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID)
+                                    .from(this.table)
+                                    .where(conditions)
+                                    .and(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID.isNotNull()))
+                            .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID)));
+        }
+
         return FlatMapUtil.flatMapFlux(
-                () -> super.createBucketConditions(access, ticketBucketFilter).flux(),
+                () -> this.createTicketBucketConditionsWithoutDate(access, ticketBucketFilter).flux(),
                 abstractCondition -> super.filter(abstractCondition).flux(),
-                (abstractCondition, conditions) -> Flux.from(this.dslContext
-                                .selectDistinct(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID)
-                                .from(this.table)
-                                .where(conditions)
-                                .and(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID.isNotNull()))
-                        .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID)));
+                (abstractCondition, conditions) -> {
+                    Condition activityCondition = this.buildActivityCondition(
+                            ticketBucketFilter.getStartDate(),
+                            ticketBucketFilter.getEndDate(),
+                            ticketBucketFilter.getStageIds());
+
+                    return Flux.from(this.dslContext
+                                    .selectDistinct(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID)
+                                    .from(this.table)
+                                    .join(ENTITY_PROCESSOR_ACTIVITIES)
+                                    .on(this.idField.eq(ENTITY_PROCESSOR_ACTIVITIES.TICKET_ID))
+                                    .where(conditions)
+                                    .and(activityCondition)
+                                    .and(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID.isNotNull()))
+                            .map(rec -> rec.get(ENTITY_PROCESSOR_TICKETS.ASSIGNED_USER_ID));
+                });
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/service/TicketBucketService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/service/TicketBucketService.java
@@ -21,6 +21,7 @@ import com.fincity.saas.entity.processor.analytics.util.ReportUtil;
 import com.fincity.saas.entity.processor.dto.Stage;
 import com.fincity.saas.entity.processor.dto.Ticket;
 import com.fincity.saas.entity.processor.dto.base.BaseUpdatableDto;
+import com.fincity.saas.entity.processor.dto.base.BaseValueDto;
 import com.fincity.saas.entity.processor.dto.product.ProductTemplate;
 import com.fincity.saas.entity.processor.enums.EntitySeries;
 import com.fincity.saas.entity.processor.jooq.tables.records.EntityProcessorTicketsRecord;
@@ -117,9 +118,9 @@ public class TicketBucketService extends BaseAnalyticsService<EntityProcessorTic
                         (access, ptFilter, sFilter) -> Mono.zip(
                                 (filter.isOnlyCurrentStageStatus()
                                                 ? this.dao.getTicketCountPerCurrentStageAndDateWithClientId(
-                                                        access, sFilter, TimePeriod.DAYS)
+                                                        access, sFilter, sFilter.getTimePeriod())
                                                 : this.dao.getTicketCountPerStageAndDateWithClientId(
-                                                        access, sFilter, TimePeriod.DAYS))
+                                                        access, sFilter, sFilter.getTimePeriod()))
                                         .collectList(),
                                 (filter.isOnlyCurrentStageStatus()
                                                 ? this.dao.getUniqueCreatedByCountPerCurrentStageAndDateWithClientId(
@@ -532,30 +533,96 @@ public class TicketBucketService extends BaseAnalyticsService<EntityProcessorTic
                 .defaultIfEmpty(List.of());
     }
 
+    private Mono<List<ULong>> getTemplateIdsFromFilter(ProcessorAccess access, TicketBucketFilter filter) {
+        if (filter.getProductTemplateIds() != null && !filter.getProductTemplateIds().isEmpty()) {
+            return Mono.just(filter.getProductTemplateIds());
+        }
+        if (filter.getStageIds() != null && !filter.getStageIds().isEmpty()) {
+            return this.stageService.getValuesFlat(
+                    access.getAppCode(),
+                    access.getClientCode(),
+                    null,
+                    null,
+                    null,
+                    filter.getStageIds().toArray(ULong[]::new))
+                    .map(stages -> stages.stream()
+                            .map(BaseValueDto::getProductTemplateId)
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .toList());
+        }
+        if (filter.getStatusIds() != null && !filter.getStatusIds().isEmpty()) {
+            return this.stageService.getValuesFlat(
+                    access.getAppCode(),
+                    access.getClientCode(),
+                    null,
+                    null,
+                    null,
+                    filter.getStatusIds().toArray(ULong[]::new))
+                    .map(stages -> stages.stream()
+                            .map(BaseValueDto::getProductTemplateId)
+                            .filter(Objects::nonNull)
+                            .distinct()
+                            .toList());
+        }
+        return Mono.just(List.of());
+    }
+
     private Mono<TicketBucketFilter> resolveProductTemplates(ProcessorAccess access, TicketBucketFilter filter) {
 
         if (filter.getProductIds() != null && !filter.getProductIds().isEmpty()) {
             return resolveProductTemplateFromProducts(access, filter);
         }
 
-        return this.dao
-                .getDistinctProductTemplateIds(access, filter)
-                .collectList()
-                .flatMap(distinctTemplateIds -> {
-                    if (distinctTemplateIds.isEmpty()) return Mono.just(filter);
+        return this.getTemplateIdsFromFilter(access, filter)
+                .flatMap(allTemplateIds -> {
+                    if (allTemplateIds.isEmpty()) {
+                        return this.dao
+                                .getDistinctProductTemplateIds(access, filter)
+                                .collectList()
+                                .flatMap(distinctTemplateIds -> {
+                                    if (distinctTemplateIds.isEmpty()) return Mono.just(filter);
 
-                    List<ULong> effectiveIds = (filter.getProductTemplateIds() != null
-                                    && !filter.getProductTemplateIds().isEmpty())
-                            ? com.fincity.saas.entity.processor.util.CollectionUtil.intersectLists(
-                                    filter.getProductTemplateIds(), distinctTemplateIds)
-                            : distinctTemplateIds;
+                                    List<ULong> effectiveIds = (filter.getProductTemplateIds() != null
+                                                    && !filter.getProductTemplateIds().isEmpty())
+                                            ? com.fincity.saas.entity.processor.util.CollectionUtil.intersectLists(
+                                                    filter.getProductTemplateIds(), distinctTemplateIds)
+                                            : distinctTemplateIds;
 
-                    if (effectiveIds.isEmpty()) return Mono.just(filter);
+                                    if (effectiveIds.isEmpty()) return Mono.just(filter);
 
-                    return Flux.fromIterable(effectiveIds)
-                            .flatMap(id -> this.productTemplateService.readById(access, id))
-                            .collectList()
-                            .flatMap(templates -> applyProductTemplateToFilter(access, filter, templates));
+                                    return Flux.fromIterable(effectiveIds)
+                                            .flatMap(id -> this.productTemplateService.readById(access, id))
+                                            .collectList()
+                                            .flatMap(templates -> applyProductTemplateToFilter(access, filter, templates));
+                                });
+                    }
+
+                    filter.setSelectedProductTemplateIds(allTemplateIds);
+
+                    return this.productService
+                            .getAllProducts(access, null)
+                            .defaultIfEmpty(List.of())
+                            .map(allProducts -> {
+                                List<Product> templateProducts = allProducts.stream()
+                                        .filter(p -> allTemplateIds.contains(p.getProductTemplateId()))
+                                        .toList();
+
+                                List<ULong> productIds = templateProducts.stream()
+                                        .map(BaseUpdatableDto::getId)
+                                        .toList();
+
+                                if (productIds.isEmpty()) {
+                                    productIds = List.of(ULong.valueOf(0));
+                                }
+
+                                filter.filterProductIds(productIds)
+                                        .setProducts(templateProducts.stream()
+                                                .map(product -> IdAndValue.of(product.getId(), product.getName()))
+                                                .toList());
+
+                                return filter;
+                            });
                 });
     }
 

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/service/TicketBucketService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/analytics/service/TicketBucketService.java
@@ -4,7 +4,6 @@ import com.fincity.nocode.reactor.util.FlatMapUtil;
 import com.fincity.saas.commons.exeception.GenericException;
 import com.fincity.saas.commons.util.LogUtil;
 import com.fincity.saas.entity.processor.analytics.dao.TicketBucketDAO;
-import com.fincity.saas.entity.processor.analytics.enums.TimePeriod;
 import com.fincity.saas.entity.processor.analytics.model.DateStatusCount;
 import com.fincity.saas.entity.processor.analytics.model.EntityDateCount;
 import com.fincity.saas.entity.processor.analytics.model.EntityEntityCount;
@@ -575,54 +574,77 @@ public class TicketBucketService extends BaseAnalyticsService<EntityProcessorTic
         }
 
         return this.getTemplateIdsFromFilter(access, filter)
-                .flatMap(allTemplateIds -> {
-                    if (allTemplateIds.isEmpty()) {
-                        return this.dao
-                                .getDistinctProductTemplateIds(access, filter)
-                                .collectList()
-                                .flatMap(distinctTemplateIds -> {
-                                    if (distinctTemplateIds.isEmpty()) return Mono.just(filter);
+                .flatMap(allTemplateIds -> allTemplateIds.isEmpty()
+                        ? resolveProductTemplatesFromTickets(access, filter)
+                        : applyKnownTemplateIdsToFilter(access, filter, allTemplateIds));
+    }
 
-                                    List<ULong> effectiveIds = (filter.getProductTemplateIds() != null
-                                                    && !filter.getProductTemplateIds().isEmpty())
-                                            ? com.fincity.saas.entity.processor.util.CollectionUtil.intersectLists(
-                                                    filter.getProductTemplateIds(), distinctTemplateIds)
-                                            : distinctTemplateIds;
+    private Mono<TicketBucketFilter> resolveProductTemplatesFromTickets(
+            ProcessorAccess access, TicketBucketFilter filter) {
 
-                                    if (effectiveIds.isEmpty()) return Mono.just(filter);
+        return this.dao
+                .getDistinctProductTemplateIds(access, filter)
+                .collectList()
+                .flatMap(distinctTemplateIds -> {
+                    if (distinctTemplateIds.isEmpty()) return Mono.just(filter);
 
-                                    return Flux.fromIterable(effectiveIds)
-                                            .flatMap(id -> this.productTemplateService.readById(access, id))
-                                            .collectList()
-                                            .flatMap(templates -> applyProductTemplateToFilter(access, filter, templates));
-                                });
+                    List<ULong> effectiveIds = (filter.getProductTemplateIds() != null
+                                    && !filter.getProductTemplateIds().isEmpty())
+                            ? com.fincity.saas.entity.processor.util.CollectionUtil.intersectLists(
+                                    filter.getProductTemplateIds(), distinctTemplateIds)
+                            : distinctTemplateIds;
+
+                    if (effectiveIds.isEmpty()) return Mono.just(filter);
+
+                    return Flux.fromIterable(effectiveIds)
+                            .flatMap(id -> this.productTemplateService.readById(access, id))
+                            .collectList()
+                            .flatMap(templates -> applyProductTemplateToFilter(access, filter, templates));
+                });
+    }
+
+    private Mono<TicketBucketFilter> applyKnownTemplateIdsToFilter(
+            ProcessorAccess access, TicketBucketFilter filter, List<ULong> allTemplateIds) {
+
+        filter.filterProductTemplateIds(allTemplateIds).setSelectedProductTemplateIds(allTemplateIds);
+
+        return Flux.fromIterable(allTemplateIds)
+                .flatMap(id -> this.productTemplateService.readById(access, id))
+                .collectList()
+                .flatMap(templates -> {
+                    filter.setProductTemplates(templates.stream()
+                            .filter(pt -> pt.getId() != null)
+                            .map(pt -> IdAndValue.of(pt.getId(), pt.getName()))
+                            .toList());
+
+                    return applyTemplateProductsToFilter(access, filter, allTemplateIds);
+                });
+    }
+
+    private Mono<TicketBucketFilter> applyTemplateProductsToFilter(
+            ProcessorAccess access, TicketBucketFilter filter, List<ULong> allTemplateIds) {
+
+        return this.productService
+                .getAllProducts(access, null)
+                .defaultIfEmpty(List.of())
+                .map(allProducts -> {
+                    List<Product> templateProducts = allProducts.stream()
+                            .filter(p -> allTemplateIds.contains(p.getProductTemplateId()))
+                            .toList();
+
+                    List<ULong> productIds =
+                            templateProducts.stream().map(BaseUpdatableDto::getId).toList();
+
+                    if (productIds.isEmpty()) {
+                        productIds = List.of(ULong.valueOf(0));
                     }
 
-                    filter.setSelectedProductTemplateIds(allTemplateIds);
+                    filter.filterProductIds(productIds)
+                            .setProducts(templateProducts.stream()
+                                    .map(product -> IdAndValue.of(product.getId(), product.getName()))
+                                    .toList());
 
-                    return this.productService
-                            .getAllProducts(access, null)
-                            .defaultIfEmpty(List.of())
-                            .map(allProducts -> {
-                                List<Product> templateProducts = allProducts.stream()
-                                        .filter(p -> allTemplateIds.contains(p.getProductTemplateId()))
-                                        .toList();
-
-                                List<ULong> productIds = templateProducts.stream()
-                                        .map(BaseUpdatableDto::getId)
-                                        .toList();
-
-                                if (productIds.isEmpty()) {
-                                    productIds = List.of(ULong.valueOf(0));
-                                }
-
-                                filter.filterProductIds(productIds)
-                                        .setProducts(templateProducts.stream()
-                                                .map(product -> IdAndValue.of(product.getId(), product.getName()))
-                                                .toList());
-
-                                return filter;
-                            });
+                    return filter;
                 });
     }
 

--- a/security/src/main/java/com/fincity/security/service/billing/InvoiceService.java
+++ b/security/src/main/java/com/fincity/security/service/billing/InvoiceService.java
@@ -243,11 +243,15 @@ public class InvoiceService {
         return FlatMapUtil.flatMapMono(
                 () -> this.appService.getAppByIdInternal(invoice.getAppId()),
                 app -> this.clientService.getClientInfoById(invoice.getClientId()),
-                (app, client) -> this.clientUrlService.getAppUrlInternal(app.getAppCode(), invoice.getAppId(),
-                        invoice.getClientId()),
-                (app, client, urlPrefix) -> this.paymentDAO.findByInvoiceIds(java.util.List.of(invoice.getId()))
-                        .collectList(),
-                (app, client, urlPrefix, payments) -> {
+                // The app URL lives under the buyer's managing client (SYSTEM for a direct
+                // customer, the reseller for a white-labelled one), never the buyer itself.
+                (app, client) -> this.clientService.getManagedClientOfClientById(invoice.getClientId()),
+                (app, client, mgmtClient) -> this.clientUrlService.getAppUrlInternal(app.getAppCode(),
+                        invoice.getAppId(),
+                        mgmtClient.getId() != null ? mgmtClient.getId() : invoice.getClientId()),
+                (app, client, mgmtClient, urlPrefix) -> this.paymentDAO
+                        .findByInvoiceIds(java.util.List.of(invoice.getId())).collectList(),
+                (app, client, mgmtClient, urlPrefix, payments) -> {
                     Map<String, Object> data = new HashMap<>();
                     data.put("urlPrefix", urlPrefix);
                     data.put("invoiceId", invoice.getId());

--- a/security/src/test/java/com/fincity/security/service/billing/InvoiceServiceTest.java
+++ b/security/src/test/java/com/fincity/security/service/billing/InvoiceServiceTest.java
@@ -74,6 +74,7 @@ class InvoiceServiceTest extends AbstractServiceUnitTest {
     private static final ULong SELLER = ULong.valueOf(10);
     private static final ULong BUYER = ULong.valueOf(20);
     private static final ULong OTHER = ULong.valueOf(30);
+    private static final ULong MGMT = ULong.valueOf(1);
     private static final ULong INVOICE_ID = ULong.valueOf(900);
     private static final String APP_CODE = "adzump";
     private static final String SELLER_CODE = "CCCC";
@@ -220,7 +221,10 @@ class InvoiceServiceTest extends AbstractServiceUnitTest {
         when(clientService.getClientInfoById(BUYER))
                 .thenReturn(Mono.just(TestDataFactory.createClient(BUYER, "MMMM", "BUS",
                         SecurityClientStatusCode.ACTIVE)));
-        when(clientUrlService.getAppUrlInternal(APP_CODE, APP_ID, BUYER))
+        when(clientService.getManagedClientOfClientById(BUYER))
+                .thenReturn(Mono.just(TestDataFactory.createClient(MGMT, "SYSTEM", "BUS",
+                        SecurityClientStatusCode.ACTIVE)));
+        when(clientUrlService.getAppUrlInternal(APP_CODE, APP_ID, MGMT))
                 .thenReturn(Mono.just("https://sitezump.com"));
         when(paymentDAO.findByInvoiceIds(List.of(INVOICE_ID))).thenReturn(Flux.empty());
         when(ecService.createEvent(any(EventQueObject.class))).thenReturn(Mono.just(true));


### PR DESCRIPTION
…legend filtering bugs

Resolved three critical issues in the CP Dashboard analytics queries:
1. Fixed Weekly/Monthly Deal Double-Counting: Replaced hardcoded `TimePeriod.DAYS` with the filter's requested time period `sFilter.getTimePeriod()`. This ensures SQL counts distinct deals at the correct weekly/monthly grouping level, preventing Java from summing daily counts and duplicating deals.
2. Fixed Database-Wide Template Fallback: Rewrote template/stage resolution to enforce template boundaries even when the query yields 0 deals. Added `getTemplateIdsFromFilter` to fetch templates from stage/status lists, and mapped them to product IDs (falling back to product ID `0` if empty) to block database-wide scans.
3. Fixed Legend Filtering (Products, Clients, and Assigned Users): Updated distinct metadata queries in `TicketBucketDAO` (`getDistinctProductIdsForDateRange`, etc.) to join the activities table and filter by active date range rather than ticket creation date when `onlyCurrentStageStatus` is false.