### PR TITLE
Add form data handling to ticket processing

### DIFF
--- a/entity-processor/pom.xml
+++ b/entity-processor/pom.xml
@@ -271,7 +271,7 @@
                                             <converter>com.fincity.saas.commons.jooq.convertor.jooq.converters.JSONtoClassConverter</converter>
                                             <includeTypes>JSON</includeTypes>
                                             <genericConverter>true</genericConverter>
-                                            <includeExpression>.*\.(OBJECT_DATA|META_DATA|AD_DATA|PAYLOAD_SNAPSHOT|PLATFORM_RESPONSE)</includeExpression>
+                                            <includeExpression>.*\.(OBJECT_DATA|META_DATA|AD_DATA|FORM_DATA|PAYLOAD_SNAPSHOT|PLATFORM_RESPONSE)</includeExpression>
                                         </forcedType>
                                         <forcedType>
                                             <userType>com.fincity.saas.entity.processor.oserver.files.model.FileDetail</userType>

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/dto/AbstractLeadBase.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/dto/AbstractLeadBase.java
@@ -43,6 +43,15 @@ public abstract class AbstractLeadBase<T extends AbstractLeadBase<T>> implements
     private Map<String, Object> customFields;
     private Map<String, Object> adData;
 
+    /**
+     * The full lead-form submission as captured at intake: {@code provider}, {@code formId},
+     * {@code leadGenId}, the normalized {@code standard} and {@code custom} answer maps, and a
+     * verbatim {@code raw} provider snapshot. Populated by the Meta collector; for the website
+     * path it stays null and is synthesized in {@code Ticket.of(CampaignTicketRequest)} from
+     * {@link #customFields} plus the standard fields above.
+     */
+    private Map<String, Object> formData;
+
     public T createLead(WebsiteDetails details) {
         this.setEmail(details.getEmail());
         this.setFullName(details.getFullName());

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/dto/Ticket.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/dto/Ticket.java
@@ -9,6 +9,7 @@ import com.fincity.saas.entity.processor.eager.relations.resolvers.field.ClientF
 import com.fincity.saas.entity.processor.eager.relations.resolvers.field.UserFieldResolver;
 import com.fincity.saas.entity.processor.enums.EntitySeries;
 
+import com.fincity.saas.entity.processor.model.common.PhoneNumber;
 import com.fincity.saas.entity.processor.model.common.RuleResult;
 import com.fincity.saas.entity.processor.model.request.CampaignTicketRequest;
 import com.fincity.saas.entity.processor.model.request.form.WalkInFormTicketRequest;
@@ -18,6 +19,7 @@ import com.fincity.saas.entity.processor.util.PhoneUtil;
 import java.io.Serial;
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -37,6 +39,11 @@ public class Ticket extends BaseProcessorDto<Ticket> {
     @Serial
     private static final long serialVersionUID = 1639822311147907381L;
 
+    // formData payload keys; mirrors MetaEntityUtil.FD_* on the collector side.
+    private static final String FORM_DATA_PROVIDER = "provider";
+    private static final String FORM_DATA_STANDARD = "standard";
+    private static final String FORM_DATA_CUSTOM = "custom";
+
     private ULong ownerId;
     private ULong assignedUserId;
     private Integer dialCode = PhoneUtil.getDefaultCallingCode();
@@ -54,6 +61,7 @@ public class Ticket extends BaseProcessorDto<Ticket> {
     private String tag;
     private Map<String, Object> metaData;
     private Map<String, Object> adData;
+    private Map<String, Object> formData;
 
     private ULong productTemplateId = null;
     private LocalDateTime latestTaskDueDate;
@@ -99,6 +107,7 @@ public class Ticket extends BaseProcessorDto<Ticket> {
         this.tag = ticket.tag;
         this.metaData = CloneUtil.cloneMapObject(ticket.metaData);
         this.adData = CloneUtil.cloneMapObject(ticket.adData);
+        this.formData = CloneUtil.cloneMapObject(ticket.formData);
         this.productTemplateId = ticket.productTemplateId;
         this.latestTaskDueDate = ticket.latestTaskDueDate;
         this.expiresOn = ticket.expiresOn;
@@ -175,7 +184,85 @@ public class Ticket extends BaseProcessorDto<Ticket> {
             ticket.setAdData(new HashMap<>(campaignTicketRequest.getLeadDetails().getAdData()));
         }
 
+        ticket.setFormData(buildFormData(campaignTicketRequest.getLeadDetails()));
+
         return ticket;
+    }
+
+    /**
+     * Folds the lead-form submission onto the ticket so nothing the form captured is lost.
+     *
+     * <p>The Meta collector already supplies a complete {@code formData}: provenance, the
+     * normalized {@code standard} / {@code custom} answer maps, and a verbatim Graph API snapshot.
+     * The website path supplies none, so {@code standard} is rebuilt here from the typed
+     * {@code LeadDetails} fields and {@code custom} falls back to {@code customFields}.
+     * Collector-supplied entries win on conflict because they preserve multi-answer questions as
+     * lists, which the flat typed fields cannot represent.
+     *
+     * <p>Only phone, email and name have real ticket columns. Every other answer ({@code city},
+     * {@code dob}, {@code gender}, {@code jobTitle}, {@code zipCode}, custom questions and the
+     * rest) reaches the database only through here.
+     */
+    private static Map<String, Object> buildFormData(CampaignTicketRequest.LeadDetails lead) {
+
+        if (lead == null) return null;
+
+        Map<String, Object> formData =
+                lead.getFormData() != null ? new LinkedHashMap<>(lead.getFormData()) : new LinkedHashMap<>();
+
+        Map<String, Object> standard = new LinkedHashMap<>();
+        putIfPresent(standard, "email", lead.getEmail() != null ? lead.getEmail().getAddress() : null);
+        putIfPresent(standard, "fullName", lead.getFullName());
+        putIfPresent(standard, "phone", phoneText(lead.getPhone()));
+        putIfPresent(standard, "companyName", lead.getCompanyName());
+        putIfPresent(standard, "workEmail", lead.getWorkEmail() != null ? lead.getWorkEmail().getAddress() : null);
+        putIfPresent(standard, "workPhoneNumber", phoneText(lead.getWorkPhoneNumber()));
+        putIfPresent(standard, "jobTitle", lead.getJobTitle());
+        putIfPresent(standard, "militaryStatus", lead.getMilitaryStatus());
+        putIfPresent(standard, "relationshipStatus", lead.getRelationshipStatus());
+        putIfPresent(standard, "maritalStatus", lead.getMaritalStatus());
+        putIfPresent(standard, "gender", lead.getGender());
+        putIfPresent(standard, "dob", lead.getDob());
+        putIfPresent(standard, "firstName", lead.getFirstName());
+        putIfPresent(standard, "lastName", lead.getLastName());
+        putIfPresent(standard, "zipCode", lead.getZipCode());
+        putIfPresent(standard, "postCode", lead.getPostCode());
+        putIfPresent(standard, "country", lead.getCountry());
+        putIfPresent(standard, "province", lead.getProvince());
+        putIfPresent(standard, "streetAddress", lead.getStreetAddress());
+        putIfPresent(standard, "state", lead.getState());
+        putIfPresent(standard, "city", lead.getCity());
+        putIfPresent(standard, "whatsappNumber", phoneText(lead.getWhatsappNumber()));
+
+        if (formData.get(FORM_DATA_STANDARD) instanceof Map<?, ?> collectorStandard)
+            collectorStandard.forEach((key, value) -> standard.put(String.valueOf(key), value));
+
+        if (!standard.isEmpty()) formData.put(FORM_DATA_STANDARD, standard);
+
+        if (!formData.containsKey(FORM_DATA_CUSTOM)
+                && lead.getCustomFields() != null
+                && !lead.getCustomFields().isEmpty())
+            formData.put(FORM_DATA_CUSTOM, new LinkedHashMap<>(lead.getCustomFields()));
+
+        if (!StringUtil.safeIsBlank(lead.getPlatform()))
+            formData.putIfAbsent(FORM_DATA_PROVIDER, lead.getPlatform());
+
+        return formData.isEmpty() ? null : formData;
+    }
+
+    private static void putIfPresent(Map<String, Object> target, String key, String value) {
+        if (!StringUtil.safeIsBlank(value)) target.put(key, value);
+    }
+
+    private static String phoneText(PhoneNumber phone) {
+        if (phone == null || StringUtil.safeIsBlank(phone.getNumber())) return null;
+
+        // PhoneUtil.parse stores the number in E164 form, so the dial code is already on it.
+        // Only prefix when a caller built the object with raw setters and skipped parsing.
+        String number = phone.getNumber();
+        if (number.startsWith("+") || phone.getCountryCode() == null) return number;
+
+        return "+" + phone.getCountryCode() + number;
     }
 
     public static Ticket of(WalkInFormTicketRequest walkInFormTicketRequest) {

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/EntityProcessorActivities.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/EntityProcessorActivities.java
@@ -179,9 +179,8 @@ public class EntityProcessorActivities extends TableImpl<EntityProcessorActiviti
     /**
      * The column
      * <code>entity_processor.entity_processor_activities.ACTIVITY_ACTION</code>.
-     * Activity Action categories for this Activity.
      */
-    public final TableField<EntityProcessorActivitiesRecord, ActivityAction> ACTIVITY_ACTION = createField(DSL.name("ACTIVITY_ACTION"), SQLDataType.VARCHAR(19).nullable(false), this, "Activity Action categories for this Activity.", new EnumConverter<String, ActivityAction>(String.class, ActivityAction.class));
+    public final TableField<EntityProcessorActivitiesRecord, ActivityAction> ACTIVITY_ACTION = createField(DSL.name("ACTIVITY_ACTION"), SQLDataType.VARCHAR(19).nullable(false), this, "", new EnumConverter<String, ActivityAction>(String.class, ActivityAction.class));
 
     /**
      * The column

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/EntityProcessorTickets.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/EntityProcessorTickets.java
@@ -215,9 +215,9 @@ public class EntityProcessorTickets extends TableImpl<EntityProcessorTicketsReco
 
     /**
      * The column <code>entity_processor.entity_processor_tickets.TAG</code>.
-     * Deal Tag
+     * Ticket Tag
      */
-    public final TableField<EntityProcessorTicketsRecord, String> TAG = createField(DSL.name("TAG"), SQLDataType.VARCHAR(32), this, "Deal Tag");
+    public final TableField<EntityProcessorTicketsRecord, String> TAG = createField(DSL.name("TAG"), SQLDataType.VARCHAR(32), this, "Ticket Tag");
 
     /**
      * The column <code>entity_processor.entity_processor_tickets.DNC</code>. Do
@@ -260,6 +260,14 @@ public class EntityProcessorTickets extends TableImpl<EntityProcessorTicketsReco
      * etc.) captured at lead intake
      */
     public final TableField<EntityProcessorTicketsRecord, Map> AD_DATA = createField(DSL.name("AD_DATA"), SQLDataType.JSON, this, "Ad attribution data (gclid, fbclid, wbraid, gbraid, _gcl_au, _fbp, _fbc, etc.) captured at lead intake", new JSONtoClassConverter<JSON, Map>(JSON.class, Map.class));
+
+    /**
+     * The column
+     * <code>entity_processor.entity_processor_tickets.FORM_DATA</code>. Lead
+     * form submission captured at intake: normalized standard + custom question
+     * answers, plus raw provider snapshot
+     */
+    public final TableField<EntityProcessorTicketsRecord, Map> FORM_DATA = createField(DSL.name("FORM_DATA"), SQLDataType.JSON, this, "Lead form submission captured at intake: normalized standard + custom question answers, plus raw provider snapshot", new JSONtoClassConverter<JSON, Map>(JSON.class, Map.class));
 
     /**
      * The column

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/records/EntityProcessorActivitiesRecord.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/records/EntityProcessorActivitiesRecord.java
@@ -310,7 +310,6 @@ public class EntityProcessorActivitiesRecord extends UpdatableRecordImpl<EntityP
     /**
      * Setter for
      * <code>entity_processor.entity_processor_activities.ACTIVITY_ACTION</code>.
-     * Activity Action categories for this Activity.
      */
     public EntityProcessorActivitiesRecord setActivityAction(ActivityAction value) {
         set(15, value);
@@ -320,7 +319,6 @@ public class EntityProcessorActivitiesRecord extends UpdatableRecordImpl<EntityP
     /**
      * Getter for
      * <code>entity_processor.entity_processor_activities.ACTIVITY_ACTION</code>.
-     * Activity Action categories for this Activity.
      */
     public ActivityAction getActivityAction() {
         return (ActivityAction) get(15);

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/records/EntityProcessorTicketsRecord.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/records/EntityProcessorTicketsRecord.java
@@ -411,7 +411,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
 
     /**
      * Setter for <code>entity_processor.entity_processor_tickets.TAG</code>.
-     * Deal Tag
+     * Ticket Tag
      */
     public EntityProcessorTicketsRecord setTag(String value) {
         set(21, value);
@@ -420,7 +420,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
 
     /**
      * Getter for <code>entity_processor.entity_processor_tickets.TAG</code>.
-     * Deal Tag
+     * Ticket Tag
      */
     public String getTag() {
         return (String) get(21);
@@ -542,11 +542,32 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
 
     /**
      * Setter for
+     * <code>entity_processor.entity_processor_tickets.FORM_DATA</code>. Lead
+     * form submission captured at intake: normalized standard + custom question
+     * answers, plus raw provider snapshot
+     */
+    public EntityProcessorTicketsRecord setFormData(Map value) {
+        set(28, value);
+        return this;
+    }
+
+    /**
+     * Getter for
+     * <code>entity_processor.entity_processor_tickets.FORM_DATA</code>. Lead
+     * form submission captured at intake: normalized standard + custom question
+     * answers, plus raw provider snapshot
+     */
+    public Map getFormData() {
+        return (Map) get(28);
+    }
+
+    /**
+     * Setter for
      * <code>entity_processor.entity_processor_tickets.CREATED_BY</code>. ID of
      * the user who created this row.
      */
     public EntityProcessorTicketsRecord setCreatedBy(ULong value) {
-        set(28, value);
+        set(29, value);
         return this;
     }
 
@@ -556,7 +577,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * the user who created this row.
      */
     public ULong getCreatedBy() {
-        return (ULong) get(28);
+        return (ULong) get(29);
     }
 
     /**
@@ -565,7 +586,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * when this row is created.
      */
     public EntityProcessorTicketsRecord setCreatedAt(LocalDateTime value) {
-        set(29, value);
+        set(30, value);
         return this;
     }
 
@@ -575,7 +596,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * when this row is created.
      */
     public LocalDateTime getCreatedAt() {
-        return (LocalDateTime) get(29);
+        return (LocalDateTime) get(30);
     }
 
     /**
@@ -584,7 +605,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * the user who updated this row.
      */
     public EntityProcessorTicketsRecord setUpdatedBy(ULong value) {
-        set(30, value);
+        set(31, value);
         return this;
     }
 
@@ -594,7 +615,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * the user who updated this row.
      */
     public ULong getUpdatedBy() {
-        return (ULong) get(30);
+        return (ULong) get(31);
     }
 
     /**
@@ -603,7 +624,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * when this row is updated.
      */
     public EntityProcessorTicketsRecord setUpdatedAt(LocalDateTime value) {
-        set(31, value);
+        set(32, value);
         return this;
     }
 
@@ -613,7 +634,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
      * when this row is updated.
      */
     public LocalDateTime getUpdatedAt() {
-        return (LocalDateTime) get(31);
+        return (LocalDateTime) get(32);
     }
 
     // -------------------------------------------------------------------------
@@ -639,7 +660,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
     /**
      * Create a detached, initialised EntityProcessorTicketsRecord
      */
-    public EntityProcessorTicketsRecord(ULong id, String appCode, String clientCode, String code, String name, String description, ULong version, ULong ownerId, ULong assignedUserId, Short dialCode, String phoneNumber, String email, ULong productId, ULong stage, ULong status, String source, String subSource, ULong campaignId, ULong adsetId, ULong adId, LocalDateTime expiresOn, String tag, Boolean dnc, Boolean tempActive, Boolean isActive, ULong clientId, Map metaData, Map adData, ULong createdBy, LocalDateTime createdAt, ULong updatedBy, LocalDateTime updatedAt) {
+    public EntityProcessorTicketsRecord(ULong id, String appCode, String clientCode, String code, String name, String description, ULong version, ULong ownerId, ULong assignedUserId, Short dialCode, String phoneNumber, String email, ULong productId, ULong stage, ULong status, String source, String subSource, ULong campaignId, ULong adsetId, ULong adId, LocalDateTime expiresOn, String tag, Boolean dnc, Boolean tempActive, Boolean isActive, ULong clientId, Map metaData, Map adData, Map formData, ULong createdBy, LocalDateTime createdAt, ULong updatedBy, LocalDateTime updatedAt) {
         super(EntityProcessorTickets.ENTITY_PROCESSOR_TICKETS);
 
         setId(id);
@@ -670,6 +691,7 @@ public class EntityProcessorTicketsRecord extends UpdatableRecordImpl<EntityProc
         setClientId(clientId);
         setMetaData(metaData);
         setAdData(adData);
+        setFormData(formData);
         setCreatedBy(createdBy);
         setCreatedAt(createdAt);
         setUpdatedBy(updatedBy);

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/model/request/CampaignTicketRequest.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/model/request/CampaignTicketRequest.java
@@ -62,6 +62,10 @@ public class CampaignTicketRequest implements Serializable, INoteRequest {
         // Any extra payload
         private Map<String, Object> customFields;
 
+        // Full lead-form submission: provider, formId, leadGenId, normalized standard/custom
+        // answer maps, and a verbatim raw provider snapshot. Landed on Ticket.formData.
+        private Map<String, Object> formData;
+
         // Ad attribution (gclid, fbclid, wbraid, gbraid, _gcl_au, _fbp, _fbc, etc.)
         private Map<String, Object> adData;
 

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/platform/MetaPlatformService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/platform/MetaPlatformService.java
@@ -395,8 +395,7 @@ public class MetaPlatformService extends AbstractAdPlatformService {
                             .flatMap(tuple -> MetaEntityUtil.normalizeMetaEntity(
                                     tuple.getT1(),
                                     tuple.getT2(),
-                                    extracted.adId(),
-                                    extracted.leadGenId(),
+                                    extracted,
                                     accessToken,
                                     integration,
                                     null,

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/EntityCollectorService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/EntityCollectorService.java
@@ -96,15 +96,21 @@ public class EntityCollectorService extends AbstractConnectionService {
                                         logId),
 
                                 (extractPayload, integration, logId, token, metaData) -> Mono.just(normalizeMetaEntity(
-                                        metaData.getT1(),
-                                        metaData.getT2(),
-                                        extractPayload.adId(),
-                                        extractPayload.leadGenId(),
-                                        token,
-                                        integration,
-                                        msgService,
-                                        entityCollectorLogService,
-                                        logId)),
+                                                metaData.getT1(),
+                                                metaData.getT2(),
+                                                extractPayload,
+                                                token,
+                                                integration,
+                                                msgService,
+                                                entityCollectorLogService,
+                                                logId)
+                                        // This Mono is subscribed twice below: once to log the
+                                        // response, once to POST it to the ticket endpoint. Without
+                                        // cache() each subscription re-ran the 3 campaign-attribution
+                                        // Graph calls and rebuilt the form snapshot, so one lead cost
+                                        // 6 Graph calls and the response logged as OUTGOING_ENTITY_DATA
+                                        // was a different instance than the one actually persisted.
+                                        .cache()),
                                 (extractPayload, integration, logId, token, metaData, normalizedEntity) ->
                                         normalizedEntity.flatMap( response -> this.entityCollectorLogService.update(
                                                 logId,

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/util/MetaEntityUtil.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/util/MetaEntityUtil.java
@@ -12,6 +12,7 @@ import com.fincity.saas.entity.processor.enums.LeadSubSource;
 import com.fincity.saas.entity.processor.model.LeadDetails;
 import com.fincity.saas.entity.processor.enums.MetaLeadFieldType;
 import com.fincity.nocode.reactor.util.FlatMapUtil;
+import com.fincity.saas.commons.util.StringUtil;
 import com.fincity.saas.entity.processor.dto.CampaignDetails;
 import com.fincity.saas.entity.processor.dto.EntityIntegration;
 import com.fincity.saas.entity.processor.dto.EntityResponse;
@@ -62,6 +63,23 @@ public final class MetaEntityUtil {
     private static final String AD_FIELDS = "id,name,adset,campaign";
     private static final String BASIC_ENTITY_FIELDS = "id,name";
     private static final String FACEBOOK = "facebook";
+
+    // formData payload keys; see Ticket.FORM_DATA_* for the ticket-side mirror.
+    private static final String FD_PROVIDER = "provider";
+    private static final String FD_FORM_ID = "formId";
+    private static final String FD_LEADGEN_ID = "leadGenId";
+    private static final String FD_STANDARD = "standard";
+    private static final String FD_CUSTOM = "custom";
+    private static final String FD_RAW = "raw";
+    private static final String FD_RAW_FIELD_DATA = "fieldData";
+    private static final String FD_RAW_QUESTIONS = "questions";
+    private static final String FACEBOOK_FORM_PROVIDER = "FACEBOOK_FORM";
+
+    // Multi-answer questions are kept as a list in formData, but the typed LeadDetails
+    // fields are all String, so they get a joined value instead.
+    private static final String MULTI_VALUE_SEPARATOR = ", ";
+
+    private static final TypeReference<List<Map<String, Object>>> RAW_LIST_TYPE = new TypeReference<>() {};
 
     // Default body buffer in Spring WebClient is 256 KB which Google Ads insights
     // responses (yearly daily-segmented data) blow past. Bump to 16 MB so large
@@ -191,17 +209,19 @@ public final class MetaEntityUtil {
     public static Mono<EntityResponse> normalizeMetaEntity(
             JsonNode incomingLead,
             JsonNode formDetails,
-            String adId,
-            String leadGenId,
+            ExtractPayload extract,
             String token,
             EntityIntegration integration,
             EntityCollectorMessageResourceService messageService,
             EntityCollectorLogService logService,
             ULong logId) {
 
+        String adId = extract != null ? extract.adId() : null;
+        String leadGenId = extract != null ? extract.leadGenId() : null;
+
         return FlatMapUtil.flatMapMonoWithNull(
                         () -> buildCampaignDetails(adId, token),
-                        campaignDetails -> buildLeadDetails(incomingLead, formDetails),
+                        campaignDetails -> buildLeadDetails(incomingLead, formDetails, extract),
                         (campaignDetails, leadDetails) -> {
                             // Stamp the leadgen id onto adData so Meta Conversions API can pick it up
                             // as user_data.lead_id for system_generated events (Meta CAPI Part 6.3).
@@ -266,7 +286,8 @@ public final class MetaEntityUtil {
                 });
     }
 
-    public static Mono<LeadDetails> buildLeadDetails(JsonNode incomingLead, JsonNode formDetails) {
+    public static Mono<LeadDetails> buildLeadDetails(
+            JsonNode incomingLead, JsonNode formDetails, ExtractPayload extract) {
 
         return FlatMapUtil.flatMapMonoWithNull(
 
@@ -274,7 +295,6 @@ public final class MetaEntityUtil {
 
                 mapper -> {
                     ObjectNode leadNode = JsonNodeFactory.instance.objectNode();
-                    ObjectNode customFieldsNode = JsonNodeFactory.instance.objectNode();
                     Map<String, String> typeMapping = new HashMap<>();
                     Map<String, String> labelMapping = new HashMap<>();
 
@@ -284,35 +304,103 @@ public final class MetaEntityUtil {
                         labelMapping.put(key, question.path(LABEL).asText());
                     }
 
+                    // Normalized views of the submission that get persisted on the ticket.
+                    // `standard` mirrors the typed LeadDetails fields; `custom` holds the custom
+                    // questions plus anything whose question type we could not map.
+                    Map<String, Object> standard = new LinkedHashMap<>();
+                    Map<String, Object> custom = new LinkedHashMap<>();
+
                     for (JsonNode field : incomingLead.path(FIELD_DATA)) {
                         String key = field.path(NAME).asText();
-                        String value = field.path(VALUES).isArray()
-                                        && !field.path(VALUES).isEmpty()
-                                ? field.path(VALUES).get(0).asText()
-                                : "";
+
+                        // Meta returns every answer as an array. Multi-select questions carry more
+                        // than one entry, so keep them all rather than just values[0].
+                        List<String> values = new ArrayList<>();
+                        field.path(VALUES).forEach(value -> values.add(value.asText()));
+
+                        Object answer = switch (values.size()) {
+                            case 0 -> "";
+                            case 1 -> values.getFirst();
+                            default -> List.copyOf(values);
+                        };
+
+                        // The typed LeadDetails fields are all String, so a multi-answer question
+                        // gets a joined value there; the list form survives in formData.
+                        String flatValue = String.join(MULTI_VALUE_SEPARATOR, values);
 
                         String type = typeMapping.get(key);
                         String label = labelMapping.get(key);
 
-                        if (CUSTOM.equalsIgnoreCase(type)) {
-                            customFieldsNode.put(label, value);
-                        } else {
-                            MetaLeadFieldType fieldType = MetaLeadFieldType.fromType(type);
-                            if (fieldType != null) {
-                                leadNode.put(fieldType.getFieldName(), value);
-                            }
+                        MetaLeadFieldType fieldType =
+                                CUSTOM.equalsIgnoreCase(type) ? null : MetaLeadFieldType.fromType(type);
+
+                        if (fieldType != null) {
+                            leadNode.put(fieldType.getFieldName(), flatValue);
+                            standard.put(fieldType.getFieldName(), answer);
+                            continue;
                         }
+
+                        // Three cases land here: CUSTOM questions, question types outside
+                        // MetaLeadFieldType, and answers whose field_data[].name never matched a
+                        // questions[].key (so `type` is null). Only the first used to be kept;
+                        // the other two were discarded with no trace.
+                        String customKey = !StringUtil.safeIsBlank(label) ? label : key;
+                        custom.put(customKey, answer);
+
+                        if (!CUSTOM.equalsIgnoreCase(type))
+                            log.warn(
+                                    "MetaEntityUtil: unmapped Meta question type '{}' for field_data"
+                                            + " key '{}' (formId={}). Captured into formData.custom"
+                                            + " under '{}' instead of being dropped.",
+                                    type,
+                                    key,
+                                    extract != null ? extract.formId() : null,
+                                    customKey);
                     }
 
-                    Map<String, Object> customFields =
-                            mapper.convertValue(customFieldsNode, new TypeReference<Map<String, Object>>() {});
                     LeadDetails lead = mapper.convertValue(leadNode, LeadDetails.class);
-                    lead.setCustomFields(customFields);
+                    lead.setCustomFields(custom);
+                    lead.setFormData(buildFormData(mapper, extract, standard, custom, incomingLead, formDetails));
                     populateStaticFields(lead, FACEBOOK, LeadSource.SOCIAL_MEDIA, LeadSubSource.FACEBOOK);
 
                     return Mono.just(lead);
                 },
                 (mapper, leadDetails) -> Mono.just(leadDetails));
+    }
+
+    /**
+     * Assembles the {@code formData} payload persisted on {@code entity_processor_tickets.FORM_DATA}:
+     * provenance, the two normalized answer maps, and a verbatim Graph API snapshot. The snapshot
+     * means an answer we failed to normalize is still recoverable and a submission can be
+     * re-examined without calling Meta again.
+     */
+    private static Map<String, Object> buildFormData(
+            ObjectMapper mapper,
+            ExtractPayload extract,
+            Map<String, Object> standard,
+            Map<String, Object> custom,
+            JsonNode incomingLead,
+            JsonNode formDetails) {
+
+        Map<String, Object> formData = new LinkedHashMap<>();
+        formData.put(FD_PROVIDER, FACEBOOK_FORM_PROVIDER);
+
+        if (extract != null) {
+            if (!StringUtil.safeIsBlank(extract.formId())) formData.put(FD_FORM_ID, extract.formId());
+            if (!StringUtil.safeIsBlank(extract.leadGenId())) formData.put(FD_LEADGEN_ID, extract.leadGenId());
+        }
+
+        formData.put(FD_STANDARD, standard);
+        formData.put(FD_CUSTOM, custom);
+
+        Map<String, Object> raw = new LinkedHashMap<>();
+        if (incomingLead != null && incomingLead.path(FIELD_DATA).isArray())
+            raw.put(FD_RAW_FIELD_DATA, mapper.convertValue(incomingLead.path(FIELD_DATA), RAW_LIST_TYPE));
+        if (formDetails != null && formDetails.path(META_QUESTION).isArray())
+            raw.put(FD_RAW_QUESTIONS, mapper.convertValue(formDetails.path(META_QUESTION), RAW_LIST_TYPE));
+        if (!raw.isEmpty()) formData.put(FD_RAW, raw);
+
+        return formData;
     }
 
     public static Mono<ResponseEntity<String>> verifyMetaWebhook(String mode, String verifyToken, String challenge, String token) {

--- a/entity-processor/src/main/resources/db/migration/V83__Alter_Tickets_Add_Form_Data.sql
+++ b/entity-processor/src/main/resources/db/migration/V83__Alter_Tickets_Add_Form_Data.sql
@@ -1,0 +1,2 @@
+ALTER TABLE entity_processor.entity_processor_tickets
+    ADD COLUMN FORM_DATA JSON NULL COMMENT 'Lead form submission captured at intake: normalized standard + custom question answers, plus raw provider snapshot' AFTER AD_DATA;

--- a/entity-processor/src/test/java/com/fincity/saas/entity/processor/util/MetaLeadFormCaptureTest.java
+++ b/entity-processor/src/test/java/com/fincity/saas/entity/processor/util/MetaLeadFormCaptureTest.java
@@ -1,0 +1,313 @@
+package com.fincity.saas.entity.processor.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fincity.saas.entity.processor.dto.Ticket;
+import com.fincity.saas.entity.processor.eager.EagerUtil;
+import com.fincity.saas.entity.processor.jooq.tables.EntityProcessorTickets;
+import com.fincity.saas.entity.processor.model.LeadDetails;
+import com.fincity.saas.entity.processor.model.common.Email;
+import com.fincity.saas.entity.processor.model.common.PhoneNumber;
+import com.fincity.saas.entity.processor.model.request.CampaignTicketRequest;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the lead-form capture path: every answer a Meta form collects has to survive into
+ * {@code LeadDetails.formData} and then onto {@code Ticket.formData}.
+ *
+ * <p>Two losses used to happen in {@code buildLeadDetails} before the EntityResponse was even
+ * built, so no ticket-side change could recover them: only {@code values[0]} was read, and any
+ * question type outside {@link com.fincity.saas.entity.processor.enums.MetaLeadFieldType} was
+ * discarded with no log line.
+ */
+class MetaLeadFormCaptureTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final MetaEntityUtil.ExtractPayload EXTRACT =
+            new MetaEntityUtil.ExtractPayload("FORM_1", "LEADGEN_1", "AD_1");
+
+    private static JsonNode json(String raw) throws JsonProcessingException {
+        return MAPPER.readTree(raw);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> section(Map<String, Object> formData, String key) {
+        Object value = formData.get(key);
+        assertInstanceOf(Map.class, value, key + " should be a map");
+        return (Map<String, Object>) value;
+    }
+
+    /**
+     * A form with a standard question, a multi-answer CUSTOM question, a question type we do not
+     * map, and an answer whose {@code name} never appears in {@code questions}. Everything must
+     * land somewhere.
+     */
+    @Test
+    void everyAnswerSurvivesIncludingUnmappedTypesAndOrphanKeys() throws Exception {
+
+        JsonNode form = json("""
+                {"questions":[
+                  {"key":"email","type":"EMAIL","label":"Email"},
+                  {"key":"full_name","type":"FULL_NAME","label":"Full name"},
+                  {"key":"city","type":"CITY","label":"City"},
+                  {"key":"amenities_x1","type":"CUSTOM","label":"Which amenities matter?"},
+                  {"key":"movein_x2","type":"MULTIPLE_CHOICE","label":"Preferred move-in"}
+                ]}""");
+
+        JsonNode lead = json("""
+                {"id":"LEADGEN_1","field_data":[
+                  {"name":"email","values":["asha@example.com"]},
+                  {"name":"full_name","values":["Asha Rao"]},
+                  {"name":"city","values":["Bengaluru"]},
+                  {"name":"amenities_x1","values":["Pool","Gym","Parking"]},
+                  {"name":"movein_x2","values":["2026-09"]},
+                  {"name":"orphan_key","values":["stray answer"]}
+                ]}""");
+
+        LeadDetails result = MetaEntityUtil.buildLeadDetails(lead, form, EXTRACT).block();
+
+        assertNotNull(result);
+
+        // Standard questions still populate the typed fields, unchanged behaviour.
+        assertEquals("asha@example.com", result.getEmail());
+        assertEquals("Asha Rao", result.getFullName());
+        assertEquals("Bengaluru", result.getCity());
+
+        Map<String, Object> formData = result.getFormData();
+        assertNotNull(formData, "formData must be populated");
+        assertEquals("FACEBOOK_FORM", formData.get("provider"));
+        assertEquals("FORM_1", formData.get("formId"));
+        assertEquals("LEADGEN_1", formData.get("leadGenId"));
+
+        Map<String, Object> standard = section(formData, "standard");
+        assertEquals("asha@example.com", standard.get("email"));
+        assertEquals("Asha Rao", standard.get("fullName"));
+        assertEquals("Bengaluru", standard.get("city"));
+
+        Map<String, Object> custom = section(formData, "custom");
+
+        // Multi-select answers keep every value, not just values[0].
+        assertEquals(List.of("Pool", "Gym", "Parking"), custom.get("Which amenities matter?"));
+
+        // MULTIPLE_CHOICE is outside MetaLeadFieldType; this used to be discarded silently.
+        assertEquals("2026-09", custom.get("Preferred move-in"));
+
+        // field_data name with no matching questions[].key, so type is null: keyed by raw key.
+        assertEquals("stray answer", custom.get("orphan_key"));
+
+        // customFields stays populated and now mirrors the custom map.
+        assertEquals(custom, result.getCustomFields());
+
+        Map<String, Object> raw = section(formData, "raw");
+        assertEquals(6, ((List<?>) raw.get("fieldData")).size(), "raw snapshot keeps all answers");
+        assertEquals(5, ((List<?>) raw.get("questions")).size(), "raw snapshot keeps the form definition");
+    }
+
+    /**
+     * A multi-answer question mapped to a typed field cannot store a list there, since every
+     * LeadDetails field is a String. It gets a joined value while formData keeps the list.
+     */
+    @Test
+    void standardMultiValueIsJoinedOnTypedFieldAndKeptAsListInFormData() throws Exception {
+
+        JsonNode form = json("""
+                {"questions":[{"key":"city","type":"CITY","label":"City"}]}""");
+
+        JsonNode lead = json("""
+                {"id":"LEADGEN_1","field_data":[
+                  {"name":"city","values":["Bengaluru","Mysuru"]}
+                ]}""");
+
+        LeadDetails result = MetaEntityUtil.buildLeadDetails(lead, form, EXTRACT).block();
+
+        assertNotNull(result);
+        assertEquals("Bengaluru, Mysuru", result.getCity());
+        assertEquals(List.of("Bengaluru", "Mysuru"), section(result.getFormData(), "standard").get("city"));
+    }
+
+    /** An answer with an empty values array must not become an empty list. */
+    @Test
+    void emptyAnswerStaysAnEmptyString() throws Exception {
+
+        JsonNode form = json("""
+                {"questions":[{"key":"note_x1","type":"CUSTOM","label":"Anything else?"}]}""");
+
+        JsonNode lead = json("""
+                {"id":"LEADGEN_1","field_data":[{"name":"note_x1","values":[]}]}""");
+
+        LeadDetails result = MetaEntityUtil.buildLeadDetails(lead, form, EXTRACT).block();
+
+        assertNotNull(result);
+        assertEquals("", section(result.getFormData(), "custom").get("Anything else?"));
+    }
+
+    /** The collector's formData has to reach the ticket intact. */
+    @Test
+    void ticketCarriesCollectorFormDataThrough() {
+
+        CampaignTicketRequest.LeadDetails lead = new CampaignTicketRequest.LeadDetails()
+                .setEmail(Email.of("asha@example.com"))
+                .setPhone(PhoneNumber.of(91, "9876543210"))
+                .setFullName("Asha Rao")
+                .setCity("Bengaluru")
+                .setSource("SOCIAL_MEDIA")
+                .setFormData(Map.of(
+                        "provider", "FACEBOOK_FORM",
+                        "formId", "FORM_1",
+                        "custom", Map.of("Which amenities matter?", List.of("Pool", "Gym"))));
+
+        Ticket ticket = Ticket.of(new CampaignTicketRequest().setLeadDetails(lead));
+
+        Map<String, Object> formData = ticket.getFormData();
+        assertNotNull(formData);
+        assertEquals("FACEBOOK_FORM", formData.get("provider"));
+        assertEquals("FORM_1", formData.get("formId"));
+        assertEquals(List.of("Pool", "Gym"), section(formData, "custom").get("Which amenities matter?"));
+
+        // Standard answers with no ticket column of their own reach the DB only through formData.
+        assertEquals("Bengaluru", section(formData, "standard").get("city"));
+    }
+
+    /**
+     * The website path supplies no formData, only customFields, so the ticket has to synthesize
+     * both sections from the typed fields.
+     */
+    @Test
+    void websiteLeadWithoutFormDataStillGetsStandardAndCustom() {
+
+        CampaignTicketRequest.LeadDetails lead = new CampaignTicketRequest.LeadDetails()
+                .setEmail(Email.of("ravi@example.com"))
+                .setFullName("Ravi Kumar")
+                .setCity("Pune")
+                .setJobTitle("Architect")
+                .setPlatform("Website")
+                .setSource("Website")
+                .setCustomFields(Map.of("Budget Range", "50L-75L"));
+
+        Ticket ticket = Ticket.of(new CampaignTicketRequest().setLeadDetails(lead));
+
+        Map<String, Object> formData = ticket.getFormData();
+        assertNotNull(formData, "website leads must still capture their form answers");
+        assertEquals("Website", formData.get("provider"));
+
+        Map<String, Object> standard = section(formData, "standard");
+        assertEquals("Pune", standard.get("city"));
+        assertEquals("Architect", standard.get("jobTitle"));
+        assertEquals("ravi@example.com", standard.get("email"));
+
+        assertEquals("50L-75L", section(formData, "custom").get("Budget Range"));
+
+        // No Meta call on this path, so there is no provider snapshot to keep.
+        assertTrue(!formData.containsKey("raw"), "website path has no raw Meta snapshot");
+    }
+
+    /**
+     * Both sides can produce a {@code standard} map. The collector's must win, because it can hold
+     * a multi-answer question as a list while the flat typed field can only hold the joined string.
+     */
+    @Test
+    void collectorStandardWinsOverTypedFieldsButGapsAreFilled() {
+
+        CampaignTicketRequest.LeadDetails lead = new CampaignTicketRequest.LeadDetails()
+                .setCity("Bengaluru, Mysuru")
+                .setJobTitle("Architect")
+                .setSource("SOCIAL_MEDIA")
+                .setFormData(Map.of("standard", Map.of("city", List.of("Bengaluru", "Mysuru"))));
+
+        Map<String, Object> standard =
+                section(Ticket.of(new CampaignTicketRequest().setLeadDetails(lead)).getFormData(), "standard");
+
+        // Collector value wins: the list survives instead of the flattened string.
+        assertEquals(List.of("Bengaluru", "Mysuru"), standard.get("city"));
+
+        // A field the collector did not send is still filled from the typed field.
+        assertEquals("Architect", standard.get("jobTitle"));
+    }
+
+    /** A lead with nothing to record must leave the column NULL rather than writing {@code {}}. */
+    @Test
+    void emptyLeadLeavesFormDataNull() {
+
+        CampaignTicketRequest.LeadDetails lead = new CampaignTicketRequest.LeadDetails().setSource("SOCIAL_MEDIA");
+
+        assertNull(
+                Ticket.of(new CampaignTicketRequest().setLeadDetails(lead)).getFormData(),
+                "nothing captured means FORM_DATA stays NULL, not an empty object");
+    }
+
+    /** Phone answers keep their dial code, which a bare number field would drop. */
+    @Test
+    void phoneAnswersKeepTheirDialCode() {
+
+        CampaignTicketRequest.LeadDetails lead = new CampaignTicketRequest.LeadDetails()
+                .setPhone(PhoneNumber.of(91, "9876543210"))
+                .setWhatsappNumber(PhoneNumber.of(91, "9876500000"))
+                .setSource("SOCIAL_MEDIA");
+
+        Map<String, Object> standard =
+                section(Ticket.of(new CampaignTicketRequest().setLeadDetails(lead)).getFormData(), "standard");
+
+        assertEquals("+919876543210", standard.get("phone"));
+        assertEquals("+919876500000", standard.get("whatsappNumber"));
+    }
+
+    /** The copy constructor has to deep-clone formData, not share the reference. */
+    @Test
+    void copyConstructorDeepClonesFormData() {
+
+        CampaignTicketRequest.LeadDetails lead = new CampaignTicketRequest.LeadDetails()
+                .setCity("Bengaluru")
+                .setSource("SOCIAL_MEDIA")
+                .setCustomFields(Map.of("Budget Range", "50L-75L"));
+
+        Ticket original = Ticket.of(new CampaignTicketRequest().setLeadDetails(lead));
+        Ticket copy = new Ticket(original);
+
+        assertNotNull(copy.getFormData());
+        assertEquals(original.getFormData(), copy.getFormData());
+        assertNotSame(original.getFormData(), copy.getFormData(), "formData must be cloned, not shared");
+    }
+
+    /** buildLeadDetails is also reachable with a null ExtractPayload; it must not blow up. */
+    @Test
+    void nullExtractPayloadIsTolerated() throws Exception {
+
+        JsonNode form = json("""
+                {"questions":[{"key":"email","type":"EMAIL","label":"Email"}]}""");
+        JsonNode lead = json("""
+                {"field_data":[{"name":"email","values":["asha@example.com"]}]}""");
+
+        LeadDetails result = MetaEntityUtil.buildLeadDetails(lead, form, null).block();
+
+        assertNotNull(result);
+        assertEquals("asha@example.com", result.getEmail());
+
+        Map<String, Object> formData = result.getFormData();
+        assertEquals("FACEBOOK_FORM", formData.get("provider"));
+        assertTrue(!formData.containsKey("formId"), "no formId when there is no ExtractPayload");
+    }
+
+    /**
+     * Guards the read contract of {@code GET /tickets/code/{code}/eager}. That endpoint selects
+     * every table field and maps each column through {@code EagerUtil.fromJooqField}, so the new
+     * column has to surface as {@code formData} in the JSON response.
+     */
+    @Test
+    void eagerReadExposesTheColumnAsFormData() {
+        assertEquals(
+                "formData",
+                EagerUtil.fromJooqField(
+                        EntityProcessorTickets.ENTITY_PROCESSOR_TICKETS.FORM_DATA.getName()));
+    }
+}


### PR DESCRIPTION
- Updated pom.xml to include FORM_DATA in forced types for jOOQ.
- Enhanced AbstractLeadBase to include formData for lead-form submissions.
- Modified Ticket class to accommodate formData and ensure it is cloned properly.
- Implemented formData handling in MetaEntityUtil to capture and structure lead-form submissions.
- Added SQL migration to alter tickets table and include FORM_DATA column.
- Created comprehensive tests in MetaLeadFormCaptureTest to validate form data capture and persistence.