### PR TITLE
Enhance ClientDAO to use selectDistinct for user retrieval and update…

### DIFF
--- a/security/src/main/java/com/fincity/security/dao/ClientDAO.java
+++ b/security/src/main/java/com/fincity/security/dao/ClientDAO.java
@@ -436,7 +436,11 @@ public class ClientDAO extends AbstractUpdatableDAO<SecurityClientRecord, ULong,
         else if (!StringUtil.safeIsBlank(appId))
             appCondition = SECURITY_APP.ID.eq(ULongUtil.valueOf(appId));
 
-        return Flux.from(this.dslContext.select(SECURITY_USER.CLIENT_ID, SECURITY_USER.ID).from(SECURITY_USER)
+        // selectDistinct: the profile/role/app joins fan a single user out into one
+        // row per (profile, role, app) that grants Owner. With no appCode/appId to
+        // narrow it - the clients listing sends neither - a user who owns four apps
+        // came back four times in that client's owners list.
+        return Flux.from(this.dslContext.selectDistinct(SECURITY_USER.CLIENT_ID, SECURITY_USER.ID).from(SECURITY_USER)
                 .leftJoin(SECURITY_PROFILE_USER).on(SECURITY_PROFILE_USER.USER_ID.eq(SECURITY_USER.ID))
                 .leftJoin(SECURITY_PROFILE).on(SECURITY_PROFILE.ID.eq(SECURITY_PROFILE_USER.PROFILE_ID))
                 .leftJoin(SECURITY_PROFILE_ROLE)

--- a/security/src/test/java/com/fincity/security/integration/ClientLifecycleIntegrationTest.java
+++ b/security/src/test/java/com/fincity/security/integration/ClientLifecycleIntegrationTest.java
@@ -127,10 +127,18 @@ class ClientLifecycleIntegrationTest extends AbstractIntegrationTest {
 		assertThat(createdClientId).isNotNull();
 		assertThat(createdClientCode).isNotBlank();
 
-		// When SYSTEM client creates a child, ClientService.create() does NOT
-		// automatically insert the client hierarchy. We insert it manually so
-		// that hierarchy-dependent tests (6-8) work correctly.
-		insertClientHierarchy(createdClientId, ULong.valueOf(1), null, null, null).block();
+		// ClientService.create() now inserts the hierarchy row for every client,
+		// including one created by a SYSTEM caller, so the hierarchy-dependent
+		// tests (6-8) find it without this test inserting anything by hand.
+		Map<String, Object> hierarchy = databaseClient
+				.sql("SELECT MANAGE_CLIENT_LEVEL_0 FROM security_client_hierarchy WHERE CLIENT_ID = :clientId")
+				.bind("clientId", createdClientId.longValue())
+				.fetch()
+				.first()
+				.block();
+
+		assertThat(hierarchy).isNotNull();
+		assertThat(((Number) hierarchy.get("MANAGE_CLIENT_LEVEL_0")).longValue()).isEqualTo(1L);
 	}
 
 	@Test

--- a/security/src/test/java/com/fincity/security/service/UserServiceTest.java
+++ b/security/src/test/java/com/fincity/security/service/UserServiceTest.java
@@ -2294,7 +2294,10 @@ class UserServiceTest extends AbstractServiceUnitTest {
 			entity.setUserName("existinguser");
 			entity.setEmailId("existing@test.com");
 
-			when(dao.readById(USER_ID)).thenReturn(Mono.just(entity));
+			// The stored user keeps its original identifiers, so this edit changes them and the
+			// collision check runs.
+			when(dao.readById(USER_ID))
+					.thenReturn(Mono.just(TestDataFactory.createActiveUser(USER_ID, BUS_CLIENT_ID)));
 
 			when(clientService.getClientTypeNCodeNClientLevel(BUS_CLIENT_ID))
 					.thenReturn(Mono.just(Tuples.of("BUS", CLIENT_CODE, "CLIENT")));
@@ -2321,7 +2324,10 @@ class UserServiceTest extends AbstractServiceUnitTest {
 			User entity = TestDataFactory.createActiveUser(USER_ID, BUS_CLIENT_ID);
 			entity.setUserName("existinguser");
 
-			when(dao.readById(USER_ID)).thenReturn(Mono.just(entity));
+			// The stored user keeps its original userName, so this edit changes it and the
+			// collision check runs.
+			when(dao.readById(USER_ID))
+					.thenReturn(Mono.just(TestDataFactory.createActiveUser(USER_ID, BUS_CLIENT_ID)));
 
 			when(clientService.getClientTypeNCodeNClientLevel(BUS_CLIENT_ID))
 					.thenReturn(Mono.just(Tuples.of("INDV", CLIENT_CODE, "CLIENT")));
@@ -2338,6 +2344,45 @@ class UserServiceTest extends AbstractServiceUnitTest {
 					.expectErrorMatches(e -> e instanceof GenericException
 							&& ((GenericException) e).getStatusCode() == HttpStatus.FORBIDDEN)
 					.verify();
+		}
+
+		@Test
+		void update_ByEntity_NonIdentifierEdit_SkipsCollisionCheck() {
+
+			ContextAuthentication ca = TestDataFactory.createSystemAuth();
+			setupSecurityContext(ca);
+
+			securityContextMock.when(SecurityContextUtil::getUsersContextUser)
+					.thenReturn(Mono.just(ca.getUser()));
+
+			securityContextMock.when(() -> SecurityContextUtil.hasAuthority(anyString(),
+						ArgumentMatchers.<List<String>>any()))
+					.thenReturn(true);
+
+			User entity = TestDataFactory.createActiveUser(USER_ID, BUS_CLIENT_ID);
+			entity.setFirstName("Renamed");
+
+			// The stored user carries the same userName, email and phone, so this edit changes no
+			// identifier and must not be refused over a collision it did not create.
+			when(dao.readById(USER_ID))
+					.thenReturn(Mono.just(TestDataFactory.createActiveUser(USER_ID, BUS_CLIENT_ID)));
+
+			when(clientService.getClientTypeNCodeNClientLevel(BUS_CLIENT_ID))
+					.thenReturn(Mono.just(Tuples.of("BUS", CLIENT_CODE, "CLIENT")));
+
+			when(clientService.isUserClientManageClient(any(ContextAuthentication.class), eq(BUS_CLIENT_ID)))
+					.thenReturn(Mono.just(true));
+
+			when(dao.update(any(User.class))).thenReturn(Mono.just(entity));
+
+			setupEvictCacheMocks(USER_ID, BUS_CLIENT_ID);
+
+			StepVerifier.create(service.update(entity))
+					.assertNext(user -> assertEquals("Renamed", user.getFirstName()))
+					.verifyComplete();
+
+			verify(dao, never()).checkUserExists(any(), any(), any(), any(), any());
+			verify(dao, never()).checkUserExistsExclude(any(), any(), any(), any(), any(), any());
 		}
 
 		@Test


### PR DESCRIPTION
… ClientLifecycleIntegrationTest to reflect automatic hierarchy insertion for SYSTEM clients. Add test for non-identifier edits in UserServiceTest to skip collision checks.