### PR TITLE
Enhance WhatsApp messaging functionality and error handling

### DIFF
--- a/commons-jooq/pom.xml
+++ b/commons-jooq/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <saas-commons-version>2.0.0</saas-commons-version>
         <jooq.version>3.20.3</jooq.version>
     </properties>

--- a/commons-mongo/pom.xml
+++ b/commons-mongo/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <saas-commons-version>2.0.0</saas-commons-version>
         <saas-commons-security-version>2.0.0</saas-commons-security-version>
         <nocode-flatmap-util-version>1.3.0</nocode-flatmap-util-version>

--- a/commons-security/pom.xml
+++ b/commons-security/pom.xml
@@ -18,7 +18,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <saas-commons-version>2.0.0</saas-commons-version>
         <feign-reactor.version>4.2.1</feign-reactor.version>
         <nocode-flatmap-util-version>1.3.0</nocode-flatmap-util-version>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -19,7 +19,7 @@
         <java.version>21</java.version>
         <feign-reactor.version>4.2.1</feign-reactor.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <xlsx-streamer.version>2.1.0</xlsx-streamer.version>
         <nocode-flatmap-util-version>1.3.0</nocode-flatmap-util-version>
     </properties>

--- a/commons2/pom.xml
+++ b/commons2/pom.xml
@@ -19,7 +19,7 @@
         <java.version>21</java.version>
         <spring-cloud.version>2024.0.2</spring-cloud.version>
         <xlsx-streamer.version>2.1.0</xlsx-streamer.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
     </properties>
     <dependencies>
         <dependency>

--- a/entity-processor/pom.xml
+++ b/entity-processor/pom.xml
@@ -42,7 +42,7 @@
         <package.c.server>entity.processor</package.c.server>
         <!-- internal -->
         <package.i.nocode-flatmap-util-version>1.3.0</package.i.nocode-flatmap-util-version>
-        <package.i.nocode-kirun-version>3.14.1</package.i.nocode-kirun-version>
+        <package.i.nocode-kirun-version>4.7.0</package.i.nocode-kirun-version>
         <package.i.saas-commons-jooq-version>2.0.0</package.i.saas-commons-jooq-version>
         <package.i.saas-commons-security-version>2.0.0</package.i.saas-commons-security-version>
         <package.i.saas-commons-version>2.0.0</package.i.saas-commons-version>

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/dao/TicketDAO.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/dao/TicketDAO.java
@@ -177,8 +177,7 @@ public class TicketDAO extends BaseProcessorDAO<EntityProcessorTicketsRecord, Ti
     }
 
     /**
-     * Resolves which deal an inbound WhatsApp message belongs to: the most recently updated active
-     * ticket on that product for that customer number.
+     * Every active deal a WhatsApp message on this number belongs to, most recently updated first.
      *
      * <p>Deliberately a plain phone match rather than reusing {@code readTicketByNumberAndEmail},
      * whose matching is driven by the per-app duplicate-detection rule. That rule can require an
@@ -186,20 +185,19 @@ public class TicketDAO extends BaseProcessorDAO<EntityProcessorTicketsRecord, Ti
      *
      * <p>Both sides store E164 with the leading {@code +} ({@code PhoneUtil.parse} on this side,
      * {@code PhoneNumber.ofWhatsapp} on the message side), so this compares like with like.
-     */
-    /**
-     * Every active deal a WhatsApp message on this number belongs to, most recently updated first.
      *
      * <p>Returns all matches rather than one because a customer can hold several deals on the same
      * product, and the thread is shared across them: they all move to the top of the inbox together
      * when a message arrives. The caller stamps the message's {@code TICKET_ID} with the first.
      *
-     * <p>{@code productId} narrows to a single product when the business number is mapped to one. A
-     * null means the number is the tenant default, which serves every product, so the match is on
-     * the customer's number alone.
+     * <p>{@code productIds} narrows to the products the business number serves. A number can serve
+     * several, which is why this takes a list rather than one id: narrowing to a single product would
+     * hide a customer's existing deal on a sibling product and manufacture a duplicate for them.
+     * Empty or null means the number serves everything, so the match is on the customer's number
+     * alone.
      */
     public Mono<List<Ticket>> readActiveByProductAndPhone(
-            ProcessorAccess access, ULong productId, PhoneNumber phoneNumber) {
+            ProcessorAccess access, List<ULong> productIds, PhoneNumber phoneNumber) {
 
         if (phoneNumber == null || phoneNumber.getNumber() == null || phoneNumber.getNumber().isBlank())
             return Mono.just(List.of());
@@ -207,7 +205,11 @@ public class TicketDAO extends BaseProcessorDAO<EntityProcessorTicketsRecord, Ti
         List<AbstractCondition> conditions = new ArrayList<>();
         conditions.add(onEitherNumber(phoneNumber.getNumber()));
 
-        if (productId != null) conditions.add(FilterCondition.make(Ticket.Fields.productId, productId));
+        if (productIds != null && !productIds.isEmpty())
+            conditions.add(new FilterCondition()
+                    .setField(Ticket.Fields.productId)
+                    .setOperator(FilterConditionOperator.IN)
+                    .setMultiValue(List.copyOf(productIds)));
 
         AbstractCondition condition = super.addAppCodeAndClientCode(ComplexCondition.and(conditions), access);
 

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/dao/message/WhatsappMessageDAO.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/dao/message/WhatsappMessageDAO.java
@@ -53,7 +53,9 @@ public class WhatsappMessageDAO
 
         Condition where = tenant(appCode, clientCode)
                 .and(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.TICKET_ID.in(ticketIds))
-                .and(this.isActiveTrue());
+                .and(this.isActiveTrue())
+                // Skip the rows that would draw a bubble with nothing in it. See hasSomethingToShow.
+                .and(this.hasSomethingToShow());
 
         if (search != null && !search.isBlank()) where = where.and(bodyMatches(search));
 
@@ -108,7 +110,9 @@ public class WhatsappMessageDAO
 
         Condition where = tenant(appCode, clientCode)
                 .and(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.TICKET_ID.in(ticketIds))
-                .and(this.isActiveTrue());
+                .and(this.isActiveTrue())
+                // Skip the rows that would draw a bubble with nothing in it. See hasSomethingToShow.
+                .and(this.hasSomethingToShow());
 
         if (search != null && !search.isBlank()) where = where.and(bodyMatches(search));
 
@@ -162,7 +166,11 @@ public class WhatsappMessageDAO
 
         Condition where = tenant(appCode, clientCode)
                 .and(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.TICKET_ID.in(ticketIds))
-                .and(this.isActiveTrue());
+                .and(this.isActiveTrue())
+                // Same filter as the thread. An empty row left by a receipt is inbound and unread by
+                // every column that decides those, so counting it put an unread badge on a
+                // conversation with nothing new in it and floated the deal to the top of the inbox.
+                .and(this.hasSomethingToShow());
 
         var unread = DSL.sum(DSL.when(
                         ENTITY_PROCESSOR_WHATSAPP_MESSAGES
@@ -213,6 +221,9 @@ public class WhatsappMessageDAO
                 .from(this.table)
                 .where(tenant(appCode, clientCode))
                 .and(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.TICKET_ID.in(ticketIds))
+                // Otherwise the newest row wins the preview line and it has no text, so the inbox
+                // shows a conversation with a blank last message.
+                .and(this.hasSomethingToShow())
                 .and(this.isActiveTrue())
                 .asTable("wa_latest");
 
@@ -450,6 +461,72 @@ public class WhatsappMessageDAO
                 .and(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.BRIDGE_SESSION_ID.eq(sessionId))
                 .and(orderKey().ge(since))
                 .and(this.isActiveTrue());
+    }
+
+    /**
+     * Rows that actually have something for a reader to look at.
+     *
+     * <p><b>The bubble containing nothing but a timestamp comes from here.</b> Every write path
+     * upserts on the provider's message id, and a delivery receipt for a message this service has
+     * never seen creates the row rather than being dropped, so the status is not lost if the receipt
+     * merely raced the message it belongs to. That is right for a race measured in milliseconds. It is
+     * wrong when the message is never coming, and re-linking a number produces exactly that by the
+     * handful: WhatsApp sends receipts for the backlog it accumulated while no device was attached,
+     * we never held those messages, and each receipt manufactures a permanent empty bubble dated to
+     * whenever the customer wrote it.
+     *
+     * <p>So the rows stay - a receipt is still a fact, and a message that turns up later fills its
+     * row in and becomes visible on its own - and the thread simply does not draw the ones that say
+     * nothing. Anything with text, an attachment, a preview, a declared media type, a reason its
+     * attachment is not coming, or a provider payload counts as something. A media message still
+     * waiting for its bytes has a declared type, so it keeps rendering as pending rather than
+     * vanishing and reappearing.
+     *
+     * <p>{@code JSON_EXTRACT} rather than a null check on the column, because a failed download used
+     * to store {@code {}} rather than nothing, and an empty object is not an attachment. Those rows
+     * are still in the table.
+     */
+    private Condition hasSomethingToShow() {
+        return ENTITY_PROCESSOR_WHATSAPP_MESSAGES
+                .BODY_TEXT
+                .isNotNull()
+                .and(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.BODY_TEXT.ne(DSL.inline("")))
+                .or(jsonHasKeys(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.MEDIA_FILE_DETAIL))
+                .or(jsonHasKeys(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.MEDIA_THUMBNAIL_FILE_DETAIL))
+                .or(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.MEDIA_MIME_TYPE.isNotNull())
+                .or(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.MEDIA_ERROR.isNotNull())
+                // A location, a shared contact or an interactive reply can carry its whole content in
+                // the payload with no body text at all, so the payload has to count.
+                .or(jsonHasKeys(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.IN_MESSAGE))
+                .or(jsonHasKeys(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.MESSAGE))
+                // And an attachment always counts, even one that never arrived.
+                //
+                // This is the difference between hiding noise and hiding history. A row typed IMAGE
+                // or VIDEO records that the customer sent something, which is worth showing even
+                // when the bytes are gone: the thread says the attachment is unavailable and a person
+                // can ask them to resend. A receipt stub records nothing at all and is typed TEXT or
+                // SYSTEM by default, because a receipt carries no type for parseType to read. So the
+                // type is what separates them, and dropping this clause would quietly delete twenty
+                // real attachments from the visible history on local alone.
+                .or(ENTITY_PROCESSOR_WHATSAPP_MESSAGES.MESSAGE_TYPE.in(
+                        WhatsappMessageType.IMAGE,
+                        WhatsappMessageType.VIDEO,
+                        WhatsappMessageType.AUDIO,
+                        WhatsappMessageType.DOCUMENT,
+                        WhatsappMessageType.STICKER));
+    }
+
+    /**
+     * Non-null and not an empty object or array. {@code {}} is stored in places null was meant.
+     *
+     * <p>{@code COALESCE} is load-bearing, not decoration. {@code JSON_LENGTH(NULL)} is NULL and
+     * {@code NULL > 0} is NULL, so without it this contributes NULL rather than false to the chain of
+     * ORs above. That happens to give the right answer today, because an OR is only true when some
+     * operand is true, but it makes the whole predicate unsafe to negate or nest later, and the reason
+     * would not be obvious to whoever did it.
+     */
+    private static Condition jsonHasKeys(Field<?> column) {
+        return DSL.condition("COALESCE(JSON_LENGTH({0}), 0) > 0", column);
     }
 
     private Condition tenant(String appCode, String clientCode) {

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/dao/product/ProductDAO.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/dao/product/ProductDAO.java
@@ -81,6 +81,31 @@ public class ProductDAO extends BaseProcessorDAO<EntityProcessorProductsRecord, 
     }
 
     /**
+     * Every product that names no linked number, and therefore sends through the tenant's default.
+     *
+     * <p>The other half of resolving which products a WhatsApp message may belong to. Scoping a
+     * message on the default number to the products that explicitly name it would miss exactly these:
+     * a deal on an unmapped product sends through the default, so its own sent messages and the
+     * customer's replies both arrive on that number and must resolve back to it.
+     *
+     * <p>Same index as {@link #readByWhatsappSessionCode} ({@code IDX1_PRODUCTS_AC_CC_WSC}), and not
+     * filtered on active for the same reason: a deactivated product still holds deals whose thread has
+     * to keep working.
+     */
+    public Mono<List<Product>> readWithoutWhatsappSession(ProcessorAccess access) {
+        return FlatMapUtil.flatMapMono(
+                () -> this.processorAccessCondition(
+                        FilterCondition.make(Product.Fields.whatsappSessionCode, null)
+                                .setOperator(FilterConditionOperator.IS_NULL),
+                        access),
+                super::filter,
+                (condition, jCondition) -> Flux.from(
+                                this.dslContext.selectFrom(this.table).where(jCondition))
+                        .map(rec -> rec.into(Product.class))
+                        .collectList());
+    }
+
+    /**
      * The tenant's oldest active product.
      *
      * <p>Used when an inbound WhatsApp message arrives from a number with no deal and the business

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/dto/message/WhatsappMessage.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/dto/message/WhatsappMessage.java
@@ -138,11 +138,52 @@ public class WhatsappMessage extends BaseUpdatableDto<WhatsappMessage> {
     private boolean mediaIsVoiceNote;
 
     /**
+     * Why the attachment never arrived, when it never will.
+     *
+     * <p>The bridge already decides this: it abandons a fetch that cannot succeed, because the media
+     * is too large or WhatsApp no longer serves it, and reports {@code mediaError} on the MEDIA_READY
+     * event. That value travelled all the way here and was then only written to a log, so nothing a
+     * reader could see ever said the attachment was not coming.
+     *
+     * <p>The visible consequence was a bubble with nothing in it. A media message whose bytes never
+     * arrived has no body either, so the thread drew a correctly dated bubble containing only its
+     * timestamp, indistinguishable from a message that was never delivered. Re-linking a number
+     * produces this by the handful: WhatsApp will not serve media for messages sent while no device
+     * was attached.
+     *
+     * <p>Distinct from {@link #mediaExpiredAt}, which means the bytes arrived and our own retention
+     * sweep removed them later. Those two have to read differently: one is history we chose to drop,
+     * the other is something we never had.
+     */
+    private String mediaError;
+
+    /**
      * When the retention sweep removed the bytes. Non-null means the file is gone deliberately,
      * which is a different thing from an attachment that has not arrived yet, and the two have to
      * read differently in the thread.
      */
     private LocalDateTime mediaExpiredAt;
+
+    /**
+     * The attachment's URL, flattened out of {@link #mediaFileDetail} for the thread to read.
+     *
+     * <p>Not a column, like {@code Ticket.latestComment}. Filled in on the read path only.
+     *
+     * <p><b>It exists because the expression engine throws rather than yielding nothing.</b>
+     * {@code ObjectOperator} raises "Cannot apply array operator on a null value" the moment it
+     * indexes into a falsy parent, so {@code Parent.mediaFileDetail.url} does not evaluate to empty
+     * when a message has no attachment - it fails, and a component whose visibility failed is hidden.
+     * Every element of a media bubble was gated on that path, including the one whose whole job was
+     * to say the attachment was unavailable, so all of them disappeared together and the bubble
+     * rendered as a date and nothing else. A scalar cannot be indexed into and cannot throw.
+     */
+    private String mediaUrl;
+
+    /** The inline preview's URL, flattened for the same reason as {@link #mediaUrl}. */
+    private String mediaThumbnailUrl;
+
+    /** The attachment's display name, flattened for the same reason as {@link #mediaUrl}. */
+    private String mediaName;
 
     /**
      * The message a reaction applies to.
@@ -214,6 +255,10 @@ public class WhatsappMessage extends BaseUpdatableDto<WhatsappMessage> {
         this.mediaThumbnailFileDetail = other.mediaThumbnailFileDetail;
         this.mediaPageCount = other.mediaPageCount;
         this.mediaIsVoiceNote = other.mediaIsVoiceNote;
+        this.mediaError = other.mediaError;
+        this.mediaUrl = other.mediaUrl;
+        this.mediaThumbnailUrl = other.mediaThumbnailUrl;
+        this.mediaName = other.mediaName;
         this.mediaExpiredAt = other.mediaExpiredAt;
         this.reactionToMessageId = other.reactionToMessageId;
         this.reactionEmoji = other.reactionEmoji;

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/EntityProcessorWhatsappMessages.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/EntityProcessorWhatsappMessages.java
@@ -352,6 +352,13 @@ public class EntityProcessorWhatsappMessages extends TableImpl<EntityProcessorWh
 
     /**
      * The column
+     * <code>entity_processor.entity_processor_whatsapp_messages.MEDIA_ERROR</code>.
+     * Why the attachment never arrived; null means it did, or is still coming
+     */
+    public final TableField<EntityProcessorWhatsappMessagesRecord, String> MEDIA_ERROR = createField(DSL.name("MEDIA_ERROR"), SQLDataType.VARCHAR(512), this, "Why the attachment never arrived; null means it did, or is still coming");
+
+    /**
+     * The column
      * <code>entity_processor.entity_processor_whatsapp_messages.MEDIA_EXPIRED_AT</code>.
      * When the retention sweep removed the bytes. Non-null means the file is
      * gone on purpose, not missing by accident.

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/records/EntityProcessorWhatsappMessagesRecord.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/jooq/tables/records/EntityProcessorWhatsappMessagesRecord.java
@@ -778,12 +778,31 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
 
     /**
      * Setter for
+     * <code>entity_processor.entity_processor_whatsapp_messages.MEDIA_ERROR</code>.
+     * Why the attachment never arrived; null means it did, or is still coming
+     */
+    public EntityProcessorWhatsappMessagesRecord setMediaError(String value) {
+        set(38, value);
+        return this;
+    }
+
+    /**
+     * Getter for
+     * <code>entity_processor.entity_processor_whatsapp_messages.MEDIA_ERROR</code>.
+     * Why the attachment never arrived; null means it did, or is still coming
+     */
+    public String getMediaError() {
+        return (String) get(38);
+    }
+
+    /**
+     * Setter for
      * <code>entity_processor.entity_processor_whatsapp_messages.MEDIA_EXPIRED_AT</code>.
      * When the retention sweep removed the bytes. Non-null means the file is
      * gone on purpose, not missing by accident.
      */
     public EntityProcessorWhatsappMessagesRecord setMediaExpiredAt(LocalDateTime value) {
-        set(38, value);
+        set(39, value);
         return this;
     }
 
@@ -794,7 +813,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * gone on purpose, not missing by accident.
      */
     public LocalDateTime getMediaExpiredAt() {
-        return (LocalDateTime) get(38);
+        return (LocalDateTime) get(39);
     }
 
     /**
@@ -804,7 +823,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * rows.
      */
     public EntityProcessorWhatsappMessagesRecord setReactionToMessageId(String value) {
-        set(39, value);
+        set(40, value);
         return this;
     }
 
@@ -815,7 +834,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * rows.
      */
     public String getReactionToMessageId() {
-        return (String) get(39);
+        return (String) get(40);
     }
 
     /**
@@ -824,7 +843,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Raw inbound message object.
      */
     public EntityProcessorWhatsappMessagesRecord setInMessage(Map value) {
-        set(40, value);
+        set(41, value);
         return this;
     }
 
@@ -834,7 +853,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Raw inbound message object.
      */
     public Map getInMessage() {
-        return (Map) get(40);
+        return (Map) get(41);
     }
 
     /**
@@ -843,7 +862,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Raw response object from WhatsApp.
      */
     public EntityProcessorWhatsappMessagesRecord setMessageResponse(Map value) {
-        set(41, value);
+        set(42, value);
         return this;
     }
 
@@ -853,7 +872,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Raw response object from WhatsApp.
      */
     public Map getMessageResponse() {
-        return (Map) get(41);
+        return (Map) get(42);
     }
 
     /**
@@ -862,7 +881,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Unused. Present only because the shared DAO base expects the column.
      */
     public EntityProcessorWhatsappMessagesRecord setName(String value) {
-        set(42, value);
+        set(43, value);
         return this;
     }
 
@@ -872,7 +891,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Unused. Present only because the shared DAO base expects the column.
      */
     public String getName() {
-        return (String) get(42);
+        return (String) get(43);
     }
 
     /**
@@ -881,7 +900,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Unused. Present only because the shared DAO base expects the column.
      */
     public EntityProcessorWhatsappMessagesRecord setTempActive(Boolean value) {
-        set(43, value);
+        set(44, value);
         return this;
     }
 
@@ -891,7 +910,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Unused. Present only because the shared DAO base expects the column.
      */
     public Boolean getTempActive() {
-        return (Boolean) get(43);
+        return (Boolean) get(44);
     }
 
     /**
@@ -900,7 +919,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Flag to check if this message is active or not.
      */
     public EntityProcessorWhatsappMessagesRecord setIsActive(Boolean value) {
-        set(44, value);
+        set(45, value);
         return this;
     }
 
@@ -910,7 +929,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Flag to check if this message is active or not.
      */
     public Boolean getIsActive() {
-        return (Boolean) get(44);
+        return (Boolean) get(45);
     }
 
     /**
@@ -919,7 +938,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * ID of the user who created this row.
      */
     public EntityProcessorWhatsappMessagesRecord setCreatedBy(ULong value) {
-        set(45, value);
+        set(46, value);
         return this;
     }
 
@@ -929,7 +948,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * ID of the user who created this row.
      */
     public ULong getCreatedBy() {
-        return (ULong) get(45);
+        return (ULong) get(46);
     }
 
     /**
@@ -938,7 +957,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Time when this row is created.
      */
     public EntityProcessorWhatsappMessagesRecord setCreatedAt(LocalDateTime value) {
-        set(46, value);
+        set(47, value);
         return this;
     }
 
@@ -948,7 +967,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Time when this row is created.
      */
     public LocalDateTime getCreatedAt() {
-        return (LocalDateTime) get(46);
+        return (LocalDateTime) get(47);
     }
 
     /**
@@ -957,7 +976,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * ID of the user who updated this row.
      */
     public EntityProcessorWhatsappMessagesRecord setUpdatedBy(ULong value) {
-        set(47, value);
+        set(48, value);
         return this;
     }
 
@@ -967,7 +986,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * ID of the user who updated this row.
      */
     public ULong getUpdatedBy() {
-        return (ULong) get(47);
+        return (ULong) get(48);
     }
 
     /**
@@ -976,7 +995,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Time when this row is updated.
      */
     public EntityProcessorWhatsappMessagesRecord setUpdatedAt(LocalDateTime value) {
-        set(48, value);
+        set(49, value);
         return this;
     }
 
@@ -986,7 +1005,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
      * Time when this row is updated.
      */
     public LocalDateTime getUpdatedAt() {
-        return (LocalDateTime) get(48);
+        return (LocalDateTime) get(49);
     }
 
     // -------------------------------------------------------------------------
@@ -1012,7 +1031,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
     /**
      * Create a detached, initialised EntityProcessorWhatsappMessagesRecord
      */
-    public EntityProcessorWhatsappMessagesRecord(ULong id, String appCode, String clientCode, ULong userId, String code, String messageId, ULong whatsappBusinessAccountId, ULong whatsappPhoneNumberId, String bridgeSessionId, String whatsappPhoneNumber, ULong ticketId, Short fromDialCode, String from, Short toDialCode, String to, String customerWaId, Short customerDialCode, String customerPhoneNumber, WhatsappMessageType messageType, WhatsappMessageStatus messageStatus, String sendDecision, ULong forcedBy, Map forceState, LocalDateTime sentTime, LocalDateTime deliveredTime, LocalDateTime readTime, LocalDateTime failedTime, String failureReason, Boolean isOutbound, String bodyText, Map message, FileDetail mediaFileDetail, FileDetail mediaThumbnailFileDetail, String mediaMimeType, ULong mediaSize, Integer mediaDurationSeconds, UInteger mediaPageCount, Boolean mediaIsVoiceNote, LocalDateTime mediaExpiredAt, String reactionToMessageId, Map inMessage, Map messageResponse, String name, Boolean tempActive, Boolean isActive, ULong createdBy, LocalDateTime createdAt, ULong updatedBy, LocalDateTime updatedAt) {
+    public EntityProcessorWhatsappMessagesRecord(ULong id, String appCode, String clientCode, ULong userId, String code, String messageId, ULong whatsappBusinessAccountId, ULong whatsappPhoneNumberId, String bridgeSessionId, String whatsappPhoneNumber, ULong ticketId, Short fromDialCode, String from, Short toDialCode, String to, String customerWaId, Short customerDialCode, String customerPhoneNumber, WhatsappMessageType messageType, WhatsappMessageStatus messageStatus, String sendDecision, ULong forcedBy, Map forceState, LocalDateTime sentTime, LocalDateTime deliveredTime, LocalDateTime readTime, LocalDateTime failedTime, String failureReason, Boolean isOutbound, String bodyText, Map message, FileDetail mediaFileDetail, FileDetail mediaThumbnailFileDetail, String mediaMimeType, ULong mediaSize, Integer mediaDurationSeconds, UInteger mediaPageCount, Boolean mediaIsVoiceNote, String mediaError, LocalDateTime mediaExpiredAt, String reactionToMessageId, Map inMessage, Map messageResponse, String name, Boolean tempActive, Boolean isActive, ULong createdBy, LocalDateTime createdAt, ULong updatedBy, LocalDateTime updatedAt) {
         super(EntityProcessorWhatsappMessages.ENTITY_PROCESSOR_WHATSAPP_MESSAGES);
 
         setId(id);
@@ -1053,6 +1072,7 @@ public class EntityProcessorWhatsappMessagesRecord extends UpdatableRecordImpl<E
         setMediaDurationSeconds(mediaDurationSeconds);
         setMediaPageCount(mediaPageCount);
         setMediaIsVoiceNote(mediaIsVoiceNote);
+        setMediaError(mediaError);
         setMediaExpiredAt(mediaExpiredAt);
         setReactionToMessageId(reactionToMessageId);
         setInMessage(inMessage);

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/model/request/message/WhatsappInboundRequest.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/model/request/message/WhatsappInboundRequest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+import org.jooq.types.ULong;
 
 /**
  * A WhatsApp event handed over by the message service.
@@ -17,6 +18,10 @@ import lombok.experimental.Accessors;
  * service owns what the conversation means, so the payload is deliberately provider-shaped and free
  * of any notion of a deal: the sender cannot know which deal a message belongs to, and the receiver
  * does not need to know how Meta framed it.
+ *
+ * <p>{@code ticketId} is the one exception and is not part of that contract. This service also
+ * records its <em>own</em> outbound sends through the same funnel, and on that path the deal is
+ * already known. The message service never sets it.
  *
  * <p>Changing a field here changes both services. Add rather than repurpose, and treat {@code
  * metaMessageId} as immutable, since it is the idempotency key that makes redelivery, outbox replay
@@ -56,9 +61,63 @@ public class WhatsappInboundRequest implements Serializable {
      */
     private String bridgeSessionId;
 
+    /**
+     * Whether the session that carried this message is the tenant's default number.
+     *
+     * <p>Needed to answer which products a message on this number may belong to. A product that names
+     * no number sends through the default, so a message on the default legitimately belongs to a deal
+     * on a product that does not name it, and scoping the match to the products that <em>do</em> name
+     * it would leave that deal unmatched: its own sent messages would stop appearing in its thread and
+     * the customer's replies would manufacture a second deal.
+     *
+     * <p>Only the message service can answer it, since the default flag lives on the session row.
+     */
+    private Boolean sessionIsDefault;
+
+    /**
+     * Whether this message was recovered from WhatsApp's history sync rather than received live.
+     *
+     * <p><b>Its only job is to stop a backfill creating deals, and that is not a nicety.</b> A sync
+     * blob carries the recent history of every chat on the handset, so with creation enabled, linking
+     * one personal number would fabricate a deal for every contact that person has ever messaged.
+     * From the inside that is indistinguishable from a sudden flood of genuine leads, which is why
+     * the deploy notes for this branch insist any history replay runs with creation off.
+     *
+     * <p>A backfilled message attaches to a deal that already exists, and is otherwise stored with no
+     * deal at all - visible in the number's history, absent from anybody's pipeline.
+     */
+    private Boolean backfilled;
+
+    /**
+     * The deal this message belongs to, when the caller already knows.
+     *
+     * <p>Set only on the outbound path, which is the one place it is knowable: a person clicked Send
+     * on a deal, or the sweeper released a message queued against one. Resolving it by phone number
+     * instead was actively wrong for a customer holding several deals, because the resolution picks
+     * the most recently updated match: an agent sending from one deal could have their message filed
+     * against another, which is exactly how one conversation appears to be spread across two.
+     *
+     * <p>Never set by the bridge or the message service, and there is nothing to guard: it arrives on
+     * an internal call from this service to itself. A genuine inbound message has no deal yet and must
+     * still go through resolution.
+     */
+    private ULong ticketId;
+
     private String customerWaId;
     private Integer customerDialCode;
     private String customerPhoneNumber;
+
+    /**
+     * The name the customer has set on their own WhatsApp profile.
+     *
+     * <p>The only thing an inbound message carries that names the person, so it is what a deal
+     * created for a stranger is called. Without it every such deal was named after its phone number.
+     *
+     * <p><b>Untrusted display text.</b> The customer types it on their own handset, so it is bounded
+     * and trimmed before it becomes a deal name, and it is never matched on: resolution stays on the
+     * phone number, which is the only identifier here that means anything.
+     */
+    private String pushName;
 
     private String from;
     private String to;

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/TicketService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/TicketService.java
@@ -98,6 +98,16 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
     private static final String AUTOMATIC_REASSIGNMENT = "Automatic Reassignment for Stage update.";
     private static final String NAMESPACE = "EntityProcessor.Ticket";
     private static final String SOURCE_WHATSAPP = "WhatsApp";
+
+    /**
+     * How much of a customer's WhatsApp profile name may become a deal name.
+     *
+     * <p>Well under {@code NAME}'s 512 characters, and that is the point: the column's width is not
+     * the right bound for a value somebody else chooses. WhatsApp's own limit is 25, so anything past
+     * this is not a name and a 512-character one would wreck every list it appears in. Truncation is
+     * safe here because nothing matches on it.
+     */
+    private static final int MAX_INBOUND_NAME_LENGTH = 128;
     private static final ClassSchema classSchema =
             ClassSchema.getInstance(ClassSchema.PackageConfig.forEntityProcessor());
     private final List<ReactiveFunction> functions = new ArrayList<>();
@@ -1439,8 +1449,8 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
      * <p>Three things happen, in order:
      *
      * <ol>
-     *   <li><b>Match.</b> Every active deal on the customer's number, within the product scope. A
-     *       null {@code productId} means the business number is the tenant default and serves every
+     *   <li><b>Match.</b> Every active deal on the customer's number, within the product scope. An
+     *       empty {@code productIds} means the business number is the tenant default and serves every
      *       product, so the match is on the number alone.
      *   <li><b>Create, when nothing matched and {@code createIfMissing}.</b> A stranger messaging
      *       the advertised number is a lead, and with the inbox gated on deal access a message with
@@ -1450,6 +1460,11 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
      *       them, so anything else would leave stale rows below a live one.
      * </ol>
      *
+     * <p>Matching and creation take separate scopes because they are separate questions. A number can
+     * serve several products, so matching has to look across all of them or a customer's existing deal
+     * on a sibling product is missed and duplicated; creating a deal has to pick exactly one, and only
+     * the caller knows which of the mapped products that should be.
+     *
      * <p>Returns the most recently updated match, which the caller stamps onto the message as its
      * {@code TICKET_ID}. Empty only when nothing matched and creation was not asked for; the message
      * is still stored, it simply has no deal.
@@ -1457,20 +1472,22 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
     public Mono<Ticket> registerWhatsappMessage(
             String appCode,
             String clientCode,
-            ULong productId,
+            WhatsappOrigin origin,
             PhoneNumber customerPhone,
             LocalDateTime occurredAt,
             boolean createIfMissing) {
 
         ProcessorAccess access = ProcessorAccess.of(appCode, clientCode, Boolean.TRUE, null, null);
         LocalDateTime messageAt = occurredAt != null ? occurredAt : LocalDateTime.now(ZoneOffset.UTC);
+        WhatsappOrigin from = origin == null ? WhatsappOrigin.unknown() : origin;
 
         return this.dao
-                .readActiveByProductAndPhone(access, productId, customerPhone)
+                .readActiveByProductAndPhone(access, from.productIds(), customerPhone)
                 .flatMap(matched -> {
                     if (!matched.isEmpty()) return Mono.just(matched);
                     if (!createIfMissing) return Mono.just(List.<Ticket>of());
-                    return this.createFromInboundWhatsapp(access, productId, customerPhone)
+                    return this.createFromInboundWhatsapp(
+                                    access, from.createUnderProductId(), customerPhone, from.customerName())
                             .map(List::of)
                             .defaultIfEmpty(List.of());
                 })
@@ -1485,22 +1502,96 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
     }
 
     /**
+     * Moves one deal up the conversation list, for a message whose deal was never in doubt.
+     *
+     * <p>The outbound counterpart to the fan-out in {@link #registerWhatsappMessage}. One deal rather
+     * than every deal on the number, because a message somebody sent went to a particular deal, and
+     * bumping its siblings would make them all look like live conversations.
+     */
+    public Mono<Integer> touchWhatsappConversation(ULong ticketId, LocalDateTime occurredAt) {
+
+        if (ticketId == null) return Mono.just(0);
+
+        return this.dao
+                .touchLastMessageAt(
+                        List.of(ticketId), occurredAt != null ? occurredAt : LocalDateTime.now(ZoneOffset.UTC))
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "TicketService.touchWhatsappConversation"));
+    }
+
+    /**
+     * Everything about where an inbound WhatsApp message came from that deal resolution cares about.
+     *
+     * <p>One record rather than three parameters because the three are read together and are easy to
+     * transpose at a call site: two of them are product ids that mean different things.
+     *
+     * @param productIds which products a match may be found in. Empty means the number serves
+     *     everything, so the match is on the customer's number alone.
+     * @param createUnderProductId the single product a brand-new deal is created in. Null falls back
+     *     to the tenant's oldest active product.
+     * @param customerName the name from the customer's own WhatsApp profile, or null. Names a new
+     *     deal; never matched on.
+     */
+    public record WhatsappOrigin(List<ULong> productIds, ULong createUnderProductId, String customerName) {
+
+        public WhatsappOrigin {
+            productIds = productIds == null ? List.of() : List.copyOf(productIds);
+        }
+
+        /** Nothing resolved: match on the number alone and create wherever the fallback lands. */
+        public static WhatsappOrigin unknown() {
+            return new WhatsappOrigin(List.of(), null, null);
+        }
+
+        /** One product for both scopes, which is what a caller holding a single product id means. */
+        public static WhatsappOrigin ofProduct(ULong productId) {
+            return new WhatsappOrigin(productId == null ? List.of() : List.of(productId), productId, null);
+        }
+    }
+
+    /**
+     * One product for both scopes and no name.
+     *
+     * <p>Kept for the {@code /internal/whatsapp/register} route, whose contract is one optional
+     * {@code productId} query parameter and is called from outside this service.
+     */
+    public Mono<Ticket> registerWhatsappMessage(
+            String appCode,
+            String clientCode,
+            ULong productId,
+            PhoneNumber customerPhone,
+            LocalDateTime occurredAt,
+            boolean createIfMissing) {
+
+        return this.registerWhatsappMessage(
+                appCode,
+                clientCode,
+                WhatsappOrigin.ofProduct(productId),
+                customerPhone,
+                occurredAt,
+                createIfMissing);
+    }
+
+    /**
      * Creates a deal for a customer who messaged in without one.
      *
      * <p>The business number carries the routing information. Mapped to a product, the deal is
      * created there. Unmapped (the tenant default number), there is nothing to disambiguate on, so
      * it lands on the oldest active product and a sales agent moves it.
      *
-     * <p>Only the phone number is known, so it stands in as the deal name until someone edits it.
+     * <p>Named from the customer's own WhatsApp profile name when they have one, and from their phone
+     * number otherwise. The profile name is the only thing an inbound message carries that names the
+     * person, and it used to be discarded two services upstream, so every deal created this way was
+     * called after a phone number and a salesperson opening their pipeline saw a column of digits.
      * Assignment, stage and owner are left to {@code checkEntity}, which runs the same distribution
      * rules as any other intake. Source is {@code WhatsApp} so these are separable from form leads.
      *
      * <p>Note this is reachable by anyone who knows the business number. Rate limiting is not built
      * yet, and the deliberate trade is that dropping the message instead would lose the highest
-     * intent lead the system can receive.
+     * intent lead the system can receive. The name is part of that exposure and is treated as such:
+     * see {@link #dealNameFrom}.
      */
     private Mono<Ticket> createFromInboundWhatsapp(
-            ProcessorAccess access, ULong productId, PhoneNumber customerPhone) {
+            ProcessorAccess access, ULong productId, PhoneNumber customerPhone, String customerName) {
 
         if (customerPhone == null || StringUtil.safeIsBlank(customerPhone.getNumber())) return Mono.empty();
 
@@ -1522,9 +1613,10 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
                             .setPhoneNumber(customerPhone.getNumber())
                             .setSource(SOURCE_WHATSAPP)
                             .setProductId(p.getId());
-                    ticket.setName(customerPhone.getNumber());
+                    ticket.setName(dealNameFrom(customerName, customerPhone));
 
-                    return this.create(access, ticket);
+                    return this.create(access, ticket)
+                            .flatMap(created -> this.logInboundWhatsappCreation(access, created));
                 })
                 .switchIfEmpty(Mono.fromRunnable(() -> logger.warn(
                         "Inbound WhatsApp from {} has no deal and no product to create one on.",
@@ -1536,6 +1628,77 @@ public class TicketService extends BaseProcessorService<EntityProcessorTicketsRe
                             e.getMessage());
                     return Mono.empty();
                 });
+    }
+
+    /**
+     * Records the creation in the deal's activity log.
+     *
+     * <p>Every other intake does this - {@code create[TicketRequest]}, {@code createForCampaign} and
+     * {@code createForWebsite} all call {@code acCreate} straight after {@code create} - and this path
+     * was the one that did not, so a deal that arrived over WhatsApp had an activity log that began
+     * mid-conversation with no record of where the lead came from. That is the first thing anybody
+     * looks at when asking how a deal got here.
+     *
+     * <p>A failure is swallowed. The deal exists and the customer's message is about to be filed
+     * against it; losing the audit line is worth a log entry, not a lost lead.
+     */
+    private Mono<Ticket> logInboundWhatsappCreation(ProcessorAccess access, Ticket created) {
+
+        return this.activityService
+                // The explicit-access overload, like createForWebsite and createForCampaign use. The
+                // single-argument one resolves the *caller's* security context, and there is no caller
+                // here: this runs on a machine-to-machine handoff from the message service, so it
+                // would find nothing and the activity would never be written - silently, because the
+                // failure is swallowed below.
+                .acCreate(access, created, null)
+                .thenReturn(created)
+                .onErrorResume(e -> {
+                    logger.error(
+                            "Created deal {} from an inbound WhatsApp message but could not write its"
+                                    + " creation activity.",
+                            created.getId(),
+                            e);
+                    return Mono.just(created);
+                });
+    }
+
+    /**
+     * What to call a deal created for a stranger who messaged in.
+     *
+     * <p>Their WhatsApp profile name when there is one, their number otherwise. The number is not a
+     * bad name so much as no name at all, and it is what every one of these deals was called.
+     *
+     * <p><b>The name is attacker-controlled and is handled accordingly.</b> Anyone who knows the
+     * business number can reach this by sending one message, and the value is whatever they typed on
+     * their own handset. So it is trimmed, bounded to the column's length, and stripped of the
+     * control characters that would let a name break the line it is rendered on or a CSV export it
+     * lands in. It is only ever a label: resolution stays on the phone number throughout, and nothing
+     * matches on this.
+     *
+     * <p>Package-private so {@code InboundWhatsappDealNameTest} can exercise the sanitising directly.
+     * It is the one part of this class that handles a value chosen by somebody outside the tenant, and
+     * testing it through the reactive create path would need the whole service mocked to assert on a
+     * string.
+     */
+    static String dealNameFrom(String customerName, PhoneNumber customerPhone) {
+
+        if (StringUtil.safeIsBlank(customerName)) return customerPhone.getNumber();
+
+        // Two passes, and the second is not tidiness. Stripping turns each control character into a
+        // space, so "Vishwas\r\nKumar" would otherwise keep a double space, and a name padded with
+        // twenty of them would read as two columns in a list.
+        String cleaned = customerName
+                .replaceAll("[\\p{Cntrl}\\p{Cf}]", " ")
+                .replaceAll("\\s{2,}", " ")
+                .trim();
+
+        // A name that was nothing but control characters. Falling back is right: an empty deal name
+        // is unusable in a list and the number at least identifies the lead.
+        if (cleaned.isEmpty()) return customerPhone.getNumber();
+
+        return cleaned.length() > MAX_INBOUND_NAME_LENGTH
+                ? cleaned.substring(0, MAX_INBOUND_NAME_LENGTH)
+                : cleaned;
     }
 
     private Mono<List<Ticket>> getTickets(

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/TicketWhatsappConversationService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/TicketWhatsappConversationService.java
@@ -176,6 +176,7 @@ public class TicketWhatsappConversationService {
     private static WhatsappThreadWindow toWindow(List<WhatsappMessage> content, long total, boolean hasMore) {
 
         foldReactions(content);
+        flattenMediaUrls(content);
 
         WhatsappThreadWindow window = new WhatsappThreadWindow()
                 .setContent(content)
@@ -225,6 +226,33 @@ public class TicketWhatsappConversationService {
         } catch (NumberFormatException e) {
             logger.warn("Ignoring an unreadable thread cursor: {}", raw);
             return null;
+        }
+    }
+
+    /**
+     * Lifts each attachment's URL out of its file-detail object onto a flat field.
+     *
+     * <p>Done here rather than left to the page, because the page cannot do it safely. The expression
+     * engine's {@code ObjectOperator} throws when it indexes into a falsy parent, so
+     * {@code Parent.mediaFileDetail.url} does not evaluate to empty for a message with no attachment:
+     * it raises, and every component gated on it is hidden. That included the line whose only job was
+     * to say the attachment was unavailable, which is why such a message drew a bubble containing its
+     * timestamp and nothing else.
+     *
+     * <p>The nested objects are left in place. They carry the name, size and path that the download
+     * link and the retention sweep both read; this only adds the one field the thread needs to branch
+     * on.
+     */
+    private static void flattenMediaUrls(List<WhatsappMessage> content) {
+
+        for (WhatsappMessage message : content) {
+            if (message.getMediaFileDetail() != null) {
+                message.setMediaUrl(message.getMediaFileDetail().getUrl());
+                message.setMediaName(message.getMediaFileDetail().getName());
+            }
+
+            if (message.getMediaThumbnailFileDetail() != null)
+                message.setMediaThumbnailUrl(message.getMediaThumbnailFileDetail().getUrl());
         }
     }
 
@@ -730,8 +758,25 @@ public class TicketWhatsappConversationService {
                                                     mediaId,
                                                     "fileLocation",
                                                     mediaPathOf(message)))
-                                    .flatMap(fileDetail -> this.whatsappMessageDAO.update(
-                                            message.setMediaFileDetail(toFileDetail(fileDetail))));
+                                    .flatMap(fileDetail -> {
+                                        FileDetail detail = toFileDetail(fileDetail);
+
+                                        // Nothing came back. Left unwritten on purpose so the next
+                                        // open tries again: storing an empty object here is what
+                                        // made one failed download permanent.
+                                        if (detail == null) {
+                                            logger.warn(
+                                                    "Media {} for WhatsApp message {} could not be"
+                                                        + " downloaded. Leaving the row alone so it can be"
+                                                        + " retried.",
+                                                    mediaId,
+                                                    messageId);
+                                            return Mono.just(message);
+                                        }
+
+                                        return this.whatsappMessageDAO.update(
+                                                message.setMediaFileDetail(detail));
+                                    });
                         })
                 .contextWrite(Context.of(LogUtil.METHOD_NAME, "TicketWhatsappConversationService.downloadMedia"));
     }
@@ -762,12 +807,25 @@ public class TicketWhatsappConversationService {
                 + message.getCode();
     }
 
+    /**
+     * Reads the files service's description of a downloaded attachment, or answers null.
+     *
+     * <p><b>Null, not an empty object.</b> This returned {@code new FileDetail()} for a null
+     * response, which serialises to {@code {}} and is worse than storing nothing twice over: the
+     * thread finds no url on it and draws an empty bubble, and the guard above
+     * ({@code mediaFileDetail != null}) then treats the row as already downloaded, so the fetch is
+     * never attempted again. One failed download became a permanently blank message.
+     */
     private static FileDetail toFileDetail(Map<String, Object> raw) {
+        if (raw == null || raw.isEmpty()) return null;
+
         FileDetail detail = new FileDetail();
-        if (raw == null) return detail;
         if (raw.get("name") instanceof String s) detail.setName(s);
         if (raw.get("url") instanceof String s) detail.setUrl(s);
-        return detail;
+
+        // Nothing usable in it. Same reasoning: an object with no url is indistinguishable from a
+        // failed download to every reader, and storing it blocks the retry.
+        return detail.getUrl() == null && detail.getName() == null ? null : detail;
     }
 
     /**

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/WhatsappInboundService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/WhatsappInboundService.java
@@ -7,15 +7,23 @@ import com.fincity.saas.entity.processor.dao.message.WhatsappMessageDAO;
 import com.fincity.saas.entity.processor.dto.message.WhatsappMessage;
 import com.fincity.saas.entity.processor.enums.message.WhatsappMessageStatus;
 import com.fincity.saas.entity.processor.enums.message.WhatsappMessageType;
+import com.fincity.saas.entity.processor.dto.product.Product;
 import com.fincity.saas.entity.processor.model.common.PhoneNumber;
+import com.fincity.saas.entity.processor.model.common.ProcessorAccess;
 import com.fincity.saas.entity.processor.model.request.message.WhatsappInboundRequest;
 import com.fincity.saas.entity.processor.oserver.files.model.FileDetail;
 import com.fincity.saas.entity.processor.service.TicketAudienceService;
 import com.fincity.saas.entity.processor.service.TicketService;
+import com.fincity.saas.entity.processor.service.product.ProductService;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.jooq.types.ULong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,16 +59,19 @@ public class WhatsappInboundService {
     private final TicketService ticketService;
     private final WhatsappEventService eventService;
     private final TicketAudienceService audienceService;
+    private final ProductService productService;
 
     public WhatsappInboundService(
             WhatsappMessageDAO dao,
             TicketService ticketService,
             WhatsappEventService eventService,
-            TicketAudienceService audienceService) {
+            TicketAudienceService audienceService,
+            ProductService productService) {
         this.audienceService = audienceService;
         this.dao = dao;
         this.ticketService = ticketService;
         this.eventService = eventService;
+        this.productService = productService;
     }
 
     public Mono<WhatsappMessage> accept(String appCode, String clientCode, WhatsappInboundRequest request) {
@@ -108,6 +119,11 @@ public class WhatsappInboundService {
      * without one has nothing to say, and this is not the place to notice orphans: that is the
      * inbound resolution's job and it logs it there.
      *
+     * <p>The kind decides whether anybody is interrupted, and only a message from the customer is.
+     * {@code MESSAGE} reaches everyone who can see the deal and raises a toast; {@code STATUS}
+     * reaches only whoever has that thread open and raises nothing. Both write the ping the thread
+     * reloads on, so nothing stops refreshing live either way.
+     *
      * <p>Returns the message unchanged and cannot fail the chain. A stale screen is a nuisance; a
      * customer message rejected because a Redis publish failed is a lost conversation.
      */
@@ -119,6 +135,16 @@ public class WhatsappInboundService {
         // A patch completes a bubble that has already been announced, rather than adding one.
         boolean patch = request.isStatusUpdate() || request.isMediaReady();
 
+        // Only a message from the customer is worth interrupting somebody for.
+        //
+        // An outbound mirror used to be announced as MESSAGE, exactly like an inbound one, so
+        // sending a message raised a notification and the customer's reply raised a second: one
+        // conversational turn, two alerts, and the first of them telling the sender what they had
+        // just typed. STATUS is the right kind for it, not silence: it still reaches whoever has
+        // that thread open, so a colleague watching sees the bubble appear live, and it raises
+        // nothing for anyone who is not looking.
+        boolean announceable = !patch && !Boolean.TRUE.equals(request.getOutbound());
+
         // One indexed read plus one audience resolution per stored message. Both used to be free,
         // because the event carried only a deal id and every browser worked out for itself whether
         // it cared. That cost one authenticated ticket read per open browser per event; this costs
@@ -126,11 +152,12 @@ public class WhatsappInboundService {
         return this.ticketService
                 .findById(message.getTicketId())
                 .flatMap(ticket -> this.audienceService.audienceFor(ticket).map(recipients -> {
-                    // The body only rides along for a real message. A status receipt has none, an
-                    // outbound mirror's text is already on the sender's screen, and a media patch
-                    // belongs to a bubble whose body was announced when it arrived - repeating it
-                    // would raise a second toast for one message.
-                    String body = patch ? null : message.getBodyText();
+                    // The body only rides along for something that will actually be announced. It is
+                    // the notification's text and nothing else reads it, so carrying it on a status
+                    // receipt, a media patch or our own outbound mirror only risks a second toast
+                    // for one message. This tracked `patch` alone until the outbound case moved,
+                    // which meant an outbound mirror carried a body it had no use for.
+                    String body = announceable ? message.getBodyText() : null;
                     return new WhatsappEventService.TicketRouting(
                             ticket.getId(),
                             ticket.getProductId(),
@@ -139,13 +166,12 @@ public class WhatsappInboundService {
                             body,
                             recipients);
                 }))
-                // STATUS rather than MESSAGE for both kinds of patch, which is what narrows them to
-                // whoever is actually looking at the thread. A receipt and a late-arriving picture
-                // are both changes to a bubble already on screen; only someone watching that deal
-                // has anywhere to put them.
-                .flatMap(routing -> patch
-                        ? this.eventService.publishStatus(appCode, clientCode, routing)
-                        : this.eventService.publishMessage(appCode, clientCode, routing))
+                // STATUS narrows to whoever is actually looking at the thread. A receipt, a
+                // late-arriving picture and a message we sent ourselves are all changes to a
+                // conversation somebody may have open; none of them is news.
+                .flatMap(routing -> announceable
+                        ? this.eventService.publishMessage(appCode, clientCode, routing)
+                        : this.eventService.publishStatus(appCode, clientCode, routing))
                 .onErrorResume(e -> {
                     logger.warn("Stored WhatsApp message {} but could not announce it.", request.getMetaMessageId(), e);
                     return Mono.empty();
@@ -276,13 +302,17 @@ public class WhatsappInboundService {
     /**
      * Finds or creates the deal this message belongs to, and moves it up the conversation list.
      *
-     * <p>Delegates to {@code registerWhatsappMessage}, which owns the product scoping, the fan-out
-     * across every deal on that number, and the decision to create one when a stranger messages in.
-     * A failure here is logged and the message still stores with no deal: losing what the customer
-     * said is worse than filing it late.
+     * <p>Delegates to {@code registerWhatsappMessage}, which owns the fan-out across the deals on
+     * that number and the decision to create one when a stranger messages in. The product scope is
+     * resolved here, because the mapping lives on this side. A failure is logged and the message
+     * still stores with no deal: losing what the customer said is worse than filing it late.
+     *
+     * <p>An outbound send is not resolved at all. See {@link #attachKnownTicket}.
      */
     private Mono<WhatsappMessage> attachTicket(
             String appCode, String clientCode, WhatsappInboundRequest request, WhatsappMessage message) {
+
+        if (request.getTicketId() != null) return this.attachKnownTicket(request, message);
 
         String customerNumber = request.getCustomerPhoneNumber() != null
                 ? request.getCustomerPhoneNumber()
@@ -290,16 +320,27 @@ public class WhatsappInboundService {
 
         if (customerNumber == null || customerNumber.isBlank()) return Mono.just(message);
 
-        return this.ticketService
-                .registerWhatsappMessage(
+        return this.resolveProducts(appCode, clientCode, request)
+                .flatMap(scope -> this.ticketService.registerWhatsappMessage(
                         appCode,
                         clientCode,
-                        ULongUtil.valueOf(request.getProductId()),
+                        new TicketService.WhatsappOrigin(
+                                scope.productIds(),
+                                scope.createUnder(),
+                                // Only from a genuine inbound message. On an outbound mirror the
+                                // push name is our own linked handset's, so naming a deal from it
+                                // would label the lead with the salesperson's WhatsApp name.
+                                Boolean.TRUE.equals(request.getOutbound()) ? null : request.getPushName()),
                         PhoneNumber.of(customerNumber),
                         occurredAt(request),
-                        // Only a real inbound message justifies creating a deal. A status update is
-                        // about something we already sent, so it never should.
-                        !request.isStatusUpdate() && !Boolean.TRUE.equals(request.getOutbound()))
+                        // Only a real, live inbound message justifies creating a deal. A status
+                        // update is about something we already sent, so it never should - and neither
+                        // does recovered history, however genuinely inbound it was: a sync blob names
+                        // every contact on the handset, and creating for those would read as a flood
+                        // of new leads rather than as the backfill it is.
+                        !request.isStatusUpdate()
+                                && !Boolean.TRUE.equals(request.getOutbound())
+                                && !Boolean.TRUE.equals(request.getBackfilled())))
                 .map(ticket -> message.setTicketId(ticket.getId()))
                 .defaultIfEmpty(message)
                 .onErrorResume(e -> {
@@ -309,6 +350,178 @@ public class WhatsappInboundService {
                             e);
                     return Mono.just(message);
                 });
+    }
+
+    /**
+     * Files a message against the deal the caller already knows it belongs to.
+     *
+     * <p>The outbound path, and the only path where the deal is knowable rather than inferred: a
+     * person clicked Send on a deal, or the sweeper released a message queued against one. Resolving
+     * it by phone number instead was wrong for any customer holding more than one deal, because the
+     * resolution answers with the most recently updated match. An agent sending from one deal could
+     * have their own message filed against another, and since each deal's thread reads only the
+     * messages stamped to it, one conversation ended up scattered across several.
+     *
+     * <p>The deal is still moved up the conversation list, because sending is activity on it. Only
+     * that one deal, unlike the inbound fan-out: a message we sent went to a particular deal.
+     */
+    private Mono<WhatsappMessage> attachKnownTicket(WhatsappInboundRequest request, WhatsappMessage message) {
+
+        return this.ticketService
+                .touchWhatsappConversation(request.getTicketId(), occurredAt(request))
+                .thenReturn(message.setTicketId(request.getTicketId()))
+                .onErrorResume(e -> {
+                    // The stamp is the part that matters and it is already applied; only the sort
+                    // order is lost, and the next message on the thread corrects it.
+                    logger.warn(
+                            "Filed WhatsApp message {} against deal {} but could not move that deal up the"
+                                    + " conversation list.",
+                            request.getMetaMessageId(),
+                            request.getTicketId(),
+                            e);
+                    return Mono.just(message.setTicketId(request.getTicketId()));
+                });
+    }
+
+    /**
+     * Which products a message on this business number belongs to, and where a new deal goes.
+     *
+     * <p>{@code productIds} scopes the match and can hold several, because one number may serve
+     * several products. {@code createUnder} is the single product a brand-new deal is created in, and
+     * is null when nothing can be resolved, which sends the caller to the tenant's oldest active
+     * product as before.
+     */
+    private record ProductScope(List<ULong> productIds, ULong createUnder) {
+
+        /**
+         * Nothing resolved: match on the customer's number alone and let creation fall back to the
+         * tenant's oldest active product, which is what happened before any of this existed.
+         */
+        private static ProductScope unscoped() {
+            return new ProductScope(List.of(), null);
+        }
+    }
+
+    /**
+     * Resolves the product scope for an inbound message from the number it arrived on.
+     *
+     * <p><b>This is the mapping the customer configures, and until now nothing on the inbound path
+     * read it.</b> The message service dispatches {@code productId} from its own
+     * {@code MESSAGE_WHATSAPP_PHONE_NUMBERS.PRODUCT_ID}, a column left over from the Cloud API that
+     * only the link call ever writes and that the numbers page has never sent. So it was null for
+     * every linked number, every inbound deal was created with no product, and creation fell through
+     * to the tenant's oldest active product: every WhatsApp deal landed on one product regardless of
+     * how the numbers screen was set up.
+     *
+     * <p>The live mapping is the reverse direction, {@code Product.whatsappSessionCode}, which is
+     * what the numbers screen writes and what outbound sending already resolves through. So this
+     * reads it, keyed on the bridge session id the dispatch already carries.
+     *
+     * <p>A declared {@code productId} still wins when one is present. It is how pre-pivot Cloud API
+     * rows and any future caller that genuinely knows the product express it, and honouring it costs
+     * a branch.
+     *
+     * <p><b>Which products the number serves is two questions, not one.</b> The products that name
+     * this session, always; plus, when this session is the tenant's <i>default</i>, the products that
+     * name no session at all, because those send through the default and so their deals' own traffic
+     * arrives on this number. Leaving the second set out was the trap: a deal on an unmapped product
+     * would stop matching, its sent messages would vanish from its own thread, and the customer's
+     * replies would manufacture a second deal for them.
+     *
+     * <p>Never fails the handoff. Every unresolved case degrades to matching on the customer's number
+     * alone, which is what happened before any of this existed, because a message filed under the
+     * wrong product is recoverable by a person and a message rejected at ingest is not.
+     */
+    private Mono<ProductScope> resolveProducts(String appCode, String clientCode, WhatsappInboundRequest request) {
+
+        ULong declared = ULongUtil.valueOf(request.getProductId());
+        if (declared != null) return Mono.just(new ProductScope(List.of(declared), declared));
+
+        if (StringUtil.safeIsBlank(request.getBridgeSessionId())) return Mono.just(ProductScope.unscoped());
+
+        ProcessorAccess access = ProcessorAccess.of(appCode, clientCode, Boolean.TRUE, null, null);
+        boolean isDefault = Boolean.TRUE.equals(request.getSessionIsDefault());
+
+        return this.productService
+                .getByWhatsappSessionCode(access, request.getBridgeSessionId())
+                .defaultIfEmpty(List.of())
+                .flatMap(mapped -> (isDefault
+                                ? this.productService.getWithoutWhatsappSession(access).defaultIfEmpty(List.of())
+                                : Mono.just(List.<Product>of()))
+                        .map(unmapped -> this.toScope(request.getBridgeSessionId(), mapped, unmapped)))
+                .onErrorResume(e -> {
+                    logger.error(
+                            "Could not resolve which products WhatsApp number {} serves. Filing this message"
+                                    + " without a product scope, which may put a new deal on the wrong product.",
+                            request.getBridgeSessionId(),
+                            e);
+                    return Mono.just(ProductScope.unscoped());
+                });
+    }
+
+    /**
+     * Turns the products a number serves into a scope.
+     *
+     * <p><b>Matching</b> spans every product in the scope, mapped and default-inherited, and includes
+     * <i>inactive</i> ones: a deal that already exists on a product somebody has since deactivated is
+     * still that customer's deal, and excluding it would create a duplicate on their next message.
+     * Matching used to ignore the scope entirely and match on the customer's number alone, which is
+     * how one customer's conversation ended up spread across deals on unrelated products.
+     *
+     * <p><b>Creation</b> has to pick exactly one, and only from the active products, because {@code
+     * createFromInboundWhatsapp} refuses an inactive one and would store the message with no deal at
+     * all. A product that explicitly names this number is preferred over one that merely inherits it
+     * as the default, which is the whole point of configuring the mapping. Lowest id, the oldest, is
+     * the only stable ordering a product carries.
+     *
+     * <p>Ambiguity is logged rather than guessed at silently. Two products sharing one number is a
+     * real configuration, and a message from a stranger carries nothing saying which they meant, so
+     * somebody has to know it is happening.
+     */
+    private ProductScope toScope(String sessionCode, List<Product> mapped, List<Product> defaultInherited) {
+
+        List<ULong> scope = Stream.concat(mapped.stream(), defaultInherited.stream())
+                .map(Product::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (scope.isEmpty()) return ProductScope.unscoped();
+
+        List<Product> mappedActive = activeByAge(mapped);
+        List<Product> inheritedActive = activeByAge(defaultInherited);
+
+        // Named beats inherited. A product that was pointed at this number deliberately is a better
+        // home for a new lead than one that only reaches it because nobody configured it.
+        List<Product> candidates = mappedActive.isEmpty() ? inheritedActive : mappedActive;
+
+        if (candidates.isEmpty()) {
+            logger.warn(
+                    "WhatsApp number {} serves only inactive product(s) {}. A new deal will go to the"
+                            + " tenant's oldest active product instead.",
+                    sessionCode,
+                    scope);
+            return new ProductScope(scope, null);
+        }
+
+        if (candidates.size() > 1)
+            logger.warn(
+                    "WhatsApp number {} serves {} products. A message from a stranger carries nothing that"
+                            + " says which, so a new deal goes to the oldest of them, {}. Give each product"
+                            + " its own number to make this unambiguous.",
+                    sessionCode,
+                    candidates.size(),
+                    candidates.getFirst().getId());
+
+        return new ProductScope(scope, candidates.getFirst().getId());
+    }
+
+    private static List<Product> activeByAge(List<Product> products) {
+        return products.stream()
+                .filter(product -> product.getId() != null)
+                .filter(Product::isActive)
+                .sorted(Comparator.comparing(Product::getId))
+                .toList();
     }
 
     private void applyStatusTimes(WhatsappMessage message, WhatsappMessageStatus status, LocalDateTime at) {
@@ -342,8 +555,12 @@ public class WhatsappInboundService {
         this.applyMediaFileDetail(message, request);
 
         if (!StringUtil.safeIsBlank(request.getMediaError())) {
-            // Nothing to store and nothing more to wait for. Recorded on the row so the thread can
-            // say the attachment is not coming rather than showing a frame that never fills.
+            // Stored, not merely logged. This comment claimed the row carried it and the code only
+            // wrote a log line, which is why a message whose attachment never arrived rendered as a
+            // bubble containing nothing but its timestamp: no body, no picture and no explanation.
+            message.setMediaError(
+                    request.getMediaError().substring(0, Math.min(request.getMediaError().length(), 500)));
+
             logger.warn(
                     "Attachment for message {} will not arrive: {}",
                     request.getMetaMessageId(),
@@ -362,6 +579,13 @@ public class WhatsappInboundService {
      */
     private void applyMediaFileDetail(WhatsappMessage message, WhatsappInboundRequest request) {
 
+        // Recorded from whichever event carries it, not only from MEDIA_READY. A backfilled message
+        // says up front that its attachment is not coming - there will never be a MEDIA_READY for it -
+        // and without this that message would render as a media bubble with nothing in it.
+        if (!StringUtil.safeIsBlank(request.getMediaError()))
+            message.setMediaError(
+                    request.getMediaError().substring(0, Math.min(request.getMediaError().length(), 500)));
+
         if (request.getMediaMimeType() != null) message.setMediaMimeType(request.getMediaMimeType());
         if (request.getMediaSize() != null) message.setMediaSize(request.getMediaSize());
         if (request.getMediaPageCount() != null) message.setMediaPageCount(request.getMediaPageCount());
@@ -378,7 +602,12 @@ public class WhatsappInboundService {
             message.setReactionToMessageId(request.getReactionToMessageId());
 
         FileDetail detail = toFileDetail(request.getMediaFileDetail());
-        if (detail != null) message.setMediaFileDetail(detail);
+        if (detail != null) {
+            message.setMediaFileDetail(detail);
+            // The bytes arrived after all, so whatever we last said about them not coming is no
+            // longer true. A retry that finally succeeds must not leave the thread still apologising.
+            message.setMediaError(null);
+        }
     }
 
     /**

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/WhatsappOutboxSweeper.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/WhatsappOutboxSweeper.java
@@ -193,7 +193,16 @@ public class WhatsappOutboxSweeper {
         }
 
         return this.sessionService
-                .sendQueued(row.getAppCode(), row.getClientCode(), session, row.getToPhone(), row.getBodyText())
+                // The deal is not in doubt here: the row was queued against it. Passing it means the
+                // stored message is filed against that deal rather than against whichever deal on the
+                // customer's number happened to be touched most recently.
+                .sendQueued(
+                        row.getAppCode(),
+                        row.getClientCode(),
+                        ticket.getId(),
+                        session,
+                        row.getToPhone(),
+                        row.getBodyText())
                 .flatMap(response -> this.outboxDao.markSent(
                         row.getId(),
                         string(response, "messageId"),

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/WhatsappSessionService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/message/WhatsappSessionService.java
@@ -322,7 +322,12 @@ public class WhatsappSessionService {
      * discarding it.
      */
     public Mono<Map<String, Object>> sendQueued(
-            String appCode, String clientCode, Map<String, Object> session, String toPhone, String text) {
+            String appCode,
+            String clientCode,
+            ULong ticketId,
+            Map<String, Object> session,
+            String toPhone,
+            String text) {
 
         String sessionId = string(session, KEY_ID);
 
@@ -331,7 +336,8 @@ public class WhatsappSessionService {
 
         return this.feignMessageService
                 .sendWhatsappSessionMessage(appCode, clientCode, sessionId, Map.of("to", toPhone, "text", text))
-                .flatMap(response -> this.recordOutbound(appCode, clientCode, session, toPhone, text, response)
+                .flatMap(response -> this.recordOutbound(
+                                appCode, clientCode, ticketId, session, toPhone, text, response)
                         .thenReturn(response))
                 .contextWrite(Context.of(LogUtil.METHOD_NAME, "WhatsappSessionService.sendQueued"));
     }
@@ -374,11 +380,12 @@ public class WhatsappSessionService {
     private Mono<Void> recordOutbound(
             String appCode,
             String clientCode,
+            ULong ticketId,
             Map<String, Object> session,
             String toPhone,
             String text,
             Map<String, Object> response) {
-        return this.recordOutbound(appCode, clientCode, session, toPhone, text, response, null, null, null);
+        return this.recordOutbound(appCode, clientCode, ticketId, session, toPhone, text, response, null, null, null);
     }
 
     /**
@@ -392,6 +399,7 @@ public class WhatsappSessionService {
     private Mono<Void> recordOutbound(
             String appCode,
             String clientCode,
+            ULong ticketId,
             Map<String, Object> session,
             String toPhone,
             String text,
@@ -410,6 +418,11 @@ public class WhatsappSessionService {
 
         WhatsappInboundRequest sent = new WhatsappInboundRequest()
                 .setMetaMessageId(messageId)
+                // The deal this went to, which every caller here already knows. Left out until now,
+                // so an outbound message was filed by resolving the customer's number - and that
+                // resolution answers with the most recently updated match, so on a customer holding
+                // two deals an agent's own message could land on the other one.
+                .setTicketId(ticketId)
                 .setEventType("MESSAGE")
                 .setMessageType((type == null ? WhatsappMessageType.TEXT : type).getValue())
                 .setMessageStatus("sent")
@@ -530,6 +543,7 @@ public class WhatsappSessionService {
                 .flatMap(response -> this.recordOutbound(
                                 access.getAppCode(),
                                 access.getClientCode(),
+                                ticket.getId(),
                                 session,
                                 to,
                                 caption,
@@ -679,6 +693,7 @@ public class WhatsappSessionService {
                 .flatMap(response -> this.recordOutbound(
                                 access.getAppCode(),
                                 access.getClientCode(),
+                                ticket.getId(),
                                 session,
                                 to,
                                 text,

--- a/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/product/ProductService.java
+++ b/entity-processor/src/main/java/com/fincity/saas/entity/processor/service/product/ProductService.java
@@ -282,6 +282,14 @@ public class ProductService extends BaseProcessorService<EntityProcessorProducts
         return this.dao.readByWhatsappSessionCode(access, sessionCode);
     }
 
+    /**
+     * Every product that names no number, and so sends through the tenant's default. See {@link
+     * com.fincity.saas.entity.processor.dao.product.ProductDAO#readWithoutWhatsappSession}.
+     */
+    public Mono<List<Product>> getWithoutWhatsappSession(ProcessorAccess access) {
+        return this.dao.readWithoutWhatsappSession(access);
+    }
+
     /** See {@link com.fincity.saas.entity.processor.dao.product.ProductDAO#readFirstActive}. */
     public Mono<Product> readFirstActive(ProcessorAccess access) {
         return this.dao.readFirstActive(access);

--- a/entity-processor/src/main/resources/db/migration/V96__Whatsapp_Media_Error.sql
+++ b/entity-processor/src/main/resources/db/migration/V96__Whatsapp_Media_Error.sql
@@ -1,0 +1,21 @@
+USE `entity_processor`;
+
+-- Why an attachment never arrived.
+--
+-- The bridge already reports this. It abandons a fetch that cannot succeed - the media is too large,
+-- WhatsApp no longer serves it, or the retries are exhausted - and sends `mediaError` on the
+-- MEDIA_READY event. The message service forwards it. Then it was only written to a log, so nothing
+-- the reader can see ever said the attachment was not coming.
+--
+-- The visible consequence is a bubble with nothing in it. A media message whose bytes never arrived
+-- has no body either, so the thread drew a correctly dated bubble containing only its timestamp,
+-- with no error anywhere and no way to tell it from a message that was never delivered. It is the
+-- ordinary outcome of re-linking a number: WhatsApp will not serve media for messages sent while no
+-- device was attached, so every one of those comes back as an empty bubble.
+--
+-- Text rather than a flag, because "too large" and "no longer available" call for different answers
+-- from the person reading: one is worth asking the customer to resend, the other is not.
+ALTER TABLE `entity_processor_whatsapp_messages`
+    ADD COLUMN `MEDIA_ERROR` VARCHAR(512) NULL
+        COMMENT 'Why the attachment never arrived; null means it did, or is still coming'
+        AFTER `MEDIA_IS_VOICE_NOTE`;

--- a/entity-processor/src/test/java/com/fincity/saas/entity/processor/service/InboundWhatsappDealNameTest.java
+++ b/entity-processor/src/test/java/com/fincity/saas/entity/processor/service/InboundWhatsappDealNameTest.java
@@ -1,0 +1,104 @@
+package com.fincity.saas.entity.processor.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fincity.saas.entity.processor.model.common.PhoneNumber;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What a deal created from an inbound WhatsApp message is called.
+ *
+ * <p>Worth its own test because the input is chosen by whoever sent the message. Anyone who knows the
+ * business number can reach the create path with one message, so this string arrives from outside the
+ * tenant and lands in a column that is rendered in lists and exported to CSV.
+ */
+class InboundWhatsappDealNameTest {
+
+    private static PhoneNumber phone() {
+        return new PhoneNumber().setCountryCode(91).setNumber("+919902079955");
+    }
+
+    @Test
+    @DisplayName("uses the customer's WhatsApp profile name when they have one")
+    void usesProfileName() {
+        assertEquals("Vishwas Kumar", TicketService.dealNameFrom("Vishwas Kumar", phone()));
+    }
+
+    /**
+     * The behaviour before the profile name was carried through, and still the answer when there is
+     * nothing better. A number is a poor name but it identifies the lead.
+     */
+    @Test
+    @DisplayName("falls back to the number when there is no profile name")
+    void fallsBackToNumber() {
+        assertEquals("+919902079955", TicketService.dealNameFrom(null, phone()));
+        assertEquals("+919902079955", TicketService.dealNameFrom("", phone()));
+        assertEquals("+919902079955", TicketService.dealNameFrom("   ", phone()));
+    }
+
+    /**
+     * A name that is only control characters sanitises to nothing, and an empty deal name is unusable
+     * in a list. Falling back rather than saving a blank is the point.
+     */
+    @Test
+    @DisplayName("falls back when the name sanitises away to nothing")
+    void fallsBackWhenNameIsOnlyControlCharacters() {
+        assertEquals("+919902079955", TicketService.dealNameFrom("\n\r\t", phone()));
+        assertEquals("+919902079955", TicketService.dealNameFrom("​‮", phone()));
+    }
+
+    /**
+     * Newlines would break the row a name is rendered on, and an embedded newline in a CSV export is
+     * the classic way a display string becomes something else.
+     *
+     * <p>Note {@code \r\n}: stripping replaces each character with a space, so without collapsing runs
+     * the name would keep a double space. That is what this case is really pinning down.
+     */
+    @Test
+    @DisplayName("strips control and format characters and collapses the gaps they leave")
+    void stripsControlCharacters() {
+        String cleaned = TicketService.dealNameFrom("Vishwas\nKumar\r\n<admin>", phone());
+
+        assertTrue(cleaned.indexOf('\n') < 0, () -> "a newline survived: " + cleaned);
+        assertTrue(cleaned.indexOf('\r') < 0, () -> "a carriage return survived: " + cleaned);
+        assertEquals("Vishwas Kumar <admin>", cleaned);
+    }
+
+    /** A name that is mostly padding reads as two columns in a list unless the runs are collapsed. */
+    @Test
+    @DisplayName("collapses internal runs of whitespace")
+    void collapsesInternalWhitespace() {
+        assertEquals("Vishwas Kumar", TicketService.dealNameFrom("Vishwas          Kumar", phone()));
+    }
+
+    /**
+     * Right-to-left override is what makes a name display as something other than what it is. It is a
+     * format character, so the same strip covers it.
+     */
+    @Test
+    @DisplayName("strips a bidirectional override out of a name")
+    void stripsBidiOverride() {
+        assertEquals("gpj.eman", TicketService.dealNameFrom("‮gpj.eman", phone()));
+    }
+
+    /**
+     * Bounded well below the column's 512 characters. WhatsApp's own profile-name limit is 25, so
+     * anything remotely near this is not a name.
+     */
+    @Test
+    @DisplayName("bounds a very long name rather than storing it whole")
+    void boundsLongNames() {
+        String name = TicketService.dealNameFrom("x".repeat(4000), phone());
+
+        assertEquals(128, name.length());
+    }
+
+    /** Trimmed, so a name padded with spaces does not sort oddly or read as indented. */
+    @Test
+    @DisplayName("trims surrounding whitespace")
+    void trimsWhitespace() {
+        assertEquals("Vishwas", TicketService.dealNameFrom("   Vishwas   ", phone()));
+    }
+}

--- a/files/pom.xml
+++ b/files/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <java.version>21</java.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <saas-commons-version>2.0.0</saas-commons-version>
         <saas-commons-jooq-version>2.0.0</saas-commons-jooq-version>
         <saas-commons-security-version>2.0.0</saas-commons-security-version>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -42,7 +42,7 @@
         <package.c.server>message</package.c.server>
         <!-- internal -->
         <package.i.nocode-flatmap-util-version>1.3.0</package.i.nocode-flatmap-util-version>
-        <package.i.nocode-kirun-version>3.14.1</package.i.nocode-kirun-version>
+        <package.i.nocode-kirun-version>4.7.0</package.i.nocode-kirun-version>
         <package.i.saas-commons-jooq-version>2.0.0</package.i.saas-commons-jooq-version>
         <package.i.saas-commons-security-version>2.0.0</package.i.saas-commons-security-version>
         <package.i.saas-commons-version>2.0.0</package.i.saas-commons-version>

--- a/message/src/main/java/com/fincity/saas/message/enums/bridge/WhatsappSessionState.java
+++ b/message/src/main/java/com/fincity/saas/message/enums/bridge/WhatsappSessionState.java
@@ -40,11 +40,25 @@ public enum WhatsappSessionState {
      * only if told which country the instance serves and which number was actually scanned. Shown as
      * a generic error it is unfixable.
      */
-    COUNTRY_MISMATCH;
+    COUNTRY_MISMATCH,
+
+    /**
+     * A different handset scanned the code from the number that was being linked.
+     *
+     * <p>Separate from {@link #COUNTRY_MISMATCH} because the two need different sentences and one of
+     * them was previously not detected at all: the pairing check compared only the *country* of the
+     * JID that scanned, so any other number in the same country linked successfully. The row then
+     * kept displaying the number somebody typed while the session ran on a different one, and
+     * messages went out from a number the CRM did not show anywhere.
+     *
+     * <p>Fixable by the customer in seconds, like a country mismatch, but only if told which number
+     * actually scanned.
+     */
+    NUMBER_MISMATCH;
 
     /** Terminal states hold a slot without being able to use it, so the reaper reclaims them. */
     public boolean isTerminal() {
-        return this == LOGGED_OUT || this == BANNED || this == COUNTRY_MISMATCH;
+        return this == LOGGED_OUT || this == BANNED || this == COUNTRY_MISMATCH || this == NUMBER_MISMATCH;
     }
 
     /** Whether a message may be handed to this session at all. */

--- a/message/src/main/java/com/fincity/saas/message/model/request/bridge/BridgeEvent.java
+++ b/message/src/main/java/com/fincity/saas/message/model/request/bridge/BridgeEvent.java
@@ -77,6 +77,15 @@ public class BridgeEvent implements Serializable {
     private String pushName;
 
     /**
+     * Whether this message came out of WhatsApp's history sync rather than arriving live.
+     *
+     * <p>Forwarded rather than acted on here. It matters two hops away, where it stops a backfill
+     * creating deals: a sync blob carries the recent history of every chat on the handset, so with
+     * creation enabled, linking one number would fabricate a deal per contact.
+     */
+    private Boolean backfilled;
+
+    /**
      * Where the bridge stored an attachment. Present only on MEDIA_READY, which is the second half
      * of a media message: the first half already arrived under this same message id.
      */

--- a/message/src/main/java/com/fincity/saas/message/model/request/bridge/BridgeSessionSnapshot.java
+++ b/message/src/main/java/com/fincity/saas/message/model/request/bridge/BridgeSessionSnapshot.java
@@ -66,4 +66,16 @@ public class BridgeSessionSnapshot implements Serializable {
     private Integer sentLastHour;
     private Integer reconnects;
     private String lastError;
+
+    /**
+     * Whether a handset ever completed a scan on this session, read by the bridge from its device
+     * store rather than from any timestamp.
+     *
+     * <p>Carried because {@code linkedAt} cannot answer the question on its own: it is absent both
+     * for a session that never paired and, before the bridge started restoring it, for every session
+     * on an instance that had restarted. The bridge's own reaper turns on this distinction, and it is
+     * worth having on this side too, so a row in the fleet view that has never had a device behind it
+     * is visibly that rather than looking like an offline customer.
+     */
+    private Boolean paired;
 }

--- a/message/src/main/java/com/fincity/saas/message/model/request/message/provider/whatsapp/WhatsappInboundDispatch.java
+++ b/message/src/main/java/com/fincity/saas/message/model/request/message/provider/whatsapp/WhatsappInboundDispatch.java
@@ -98,6 +98,38 @@ public class WhatsappInboundDispatch implements Serializable {
     private String bridgeSessionId;
 
     /**
+     * The name the customer has set on their own WhatsApp profile, as WhatsApp sends it with every
+     * inbound message.
+     *
+     * <p>Carried because it is the only thing in an inbound message that names the person. Without
+     * it, a deal created for a stranger who messages in can only be called after their phone number,
+     * which is what every such deal was called. The bridge has always sent it; this hop simply never
+     * copied it across.
+     *
+     * <p>Untrusted display text, set by whoever is messaging. It names a deal and is never matched
+     * on, so the consumer bounds its length and treats a blank as absent.
+     */
+    private String pushName;
+
+    /**
+     * Whether the number this arrived on is the tenant's default.
+     *
+     * <p>Only this service can answer it, because the flag lives on the session row here. The
+     * consumer needs it to decide which products a message on this number may belong to: a product
+     * that names no number sends through the default, so a message on the default legitimately
+     * belongs to a deal on a product that does not name it.
+     */
+    private Boolean sessionIsDefault;
+
+    /**
+     * Whether this message was recovered from WhatsApp's history sync rather than received live.
+     *
+     * <p>Carried so the consumer can refuse to create deals for it. See
+     * {@code BridgeEvent.backfilled}.
+     */
+    private Boolean backfilled;
+
+    /**
      * Tappable actions the sender attached: a "Pay Now" URL, a call button, a quick reply.
      *
      * <p>Flat maps rather than a typed model on purpose. This service only forwards them, and the

--- a/message/src/main/java/com/fincity/saas/message/service/bridge/BridgeEventIngestService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/bridge/BridgeEventIngestService.java
@@ -161,6 +161,17 @@ public class BridgeEventIngestService {
                 // looked the event up by - and simply never copied across, which left every inbound
                 // row with a null and the pacing layer's reply count reading zero.
                 .setBridgeSessionId(session.getCode())
+                // The customer's own WhatsApp profile name. Present on the bridge's event all along
+                // and never copied, which is why a deal created for a stranger messaging in could
+                // only be named after their phone number.
+                .setPushName(event.getPushName())
+                // Whether this number is the tenant's fallback. The consumer cannot know it - the
+                // flag is on the row here - and needs it to work out which products a message on
+                // this number may belong to.
+                .setSessionIsDefault(Boolean.TRUE.equals(session.getIsDefault()))
+                // Recovered history rather than a live message. Forwarded untouched; the consumer
+                // uses it to refuse deal creation.
+                .setBackfilled(Boolean.TRUE.equals(event.getBackfilled()))
                 .setMediaFileDetail(event.getMediaFileDetail())
                 .setMediaMimeType(event.getMediaMimeType())
                 .setMediaFileName(event.getMediaFileName())

--- a/message/src/main/java/com/fincity/saas/message/service/bridge/BridgeSessionService.java
+++ b/message/src/main/java/com/fincity/saas/message/service/bridge/BridgeSessionService.java
@@ -60,6 +60,63 @@ public class BridgeSessionService {
     }
 
     /**
+     * Starts linking a number.
+     *
+     * <p>Checks up front whether the number already has a placed session, rather than letting it
+     * reach the unique key on the generated linked-number column. The constraint is correct and
+     * stays; the point is that a customer clicking Link twice is an ordinary thing to do and deserves
+     * an answer instead of an integrity violation, whose text used to end up on screen.
+     *
+     * <p>A number whose previous attempt never paired is <b>relinked</b> rather than refused. That is
+     * the difference between an ordinary retry working and not, and it used not to work at all: a
+     * pairing nobody scans leaves a row holding its instance, so every later attempt on that number
+     * was refused, and the customer had no way to see the code again either. Nothing self-healed it,
+     * because an expired attempt lands in DISCONNECTED and the bridge does not retire that state.
+     * Both halves are fixed; this is the half that also covers rows the bridge has already forgotten,
+     * which is every one of them after an instance restart.
+     */
+    public Mono<BridgeSessionSnapshot> createSession(
+            MessageAccess access, String phone, ULong productId, String ownerService) {
+
+        return this.sessionDao
+                .getPlacedByNumber(access.getAppCode(), access.getClientCode(), phone)
+                .flatMap(existing -> this.relinkOrRefuse(access, existing, phone, productId, ownerService))
+                .switchIfEmpty(Mono.defer(() -> this.startLinking(access, phone, productId, ownerService)))
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "BridgeSessionService.createSession"));
+    }
+
+    /**
+     * Decides what a second link attempt on the same number means.
+     *
+     * <p>{@code LINKED_AT} is the whole test, and it is exact rather than a heuristic: it is written
+     * only when a handset actually completed a scan. So a null means this row has never had a device
+     * behind it, has no conversation history hanging off it and no session at WhatsApp to lose.
+     * Recycling it costs nothing and is what the customer is asking for.
+     *
+     * <p>A row that <em>did</em> pair is refused, exactly as before. Relinking that automatically
+     * would discard a live device store, or one the customer unlinked from their handset five minutes
+     * ago and may want to ask about, on the strength of somebody retyping a number. It stays in the
+     * list with an Unlink button, which is a decision for a person.
+     */
+    private Mono<BridgeSessionSnapshot> relinkOrRefuse(
+            MessageAccess access, WhatsappPhoneNumber existing, String phone, ULong productId, String ownerService) {
+
+        if (existing.getLinkedAt() != null)
+            return Mono.error(new BridgeNumberAlreadyLinkedException(
+                    phone, existing.getSessionState() == null ? null : existing.getSessionState().name()));
+
+        logger.info(
+                "Number {} already has session {} in state {}, which never paired. Retiring it and"
+                        + " starting a fresh link rather than refusing the retry.",
+                phone,
+                existing.getCode(),
+                existing.getSessionState());
+
+        return this.release(access, existing.getCode(), "replaced by a fresh link attempt")
+                .then(Mono.defer(() -> this.startLinking(access, phone, productId, ownerService)));
+    }
+
+    /**
      * Creates a session and asks its instance to start pairing.
      *
      * <p>Order matters and is not arbitrary. The row is written first so the session id exists
@@ -68,26 +125,13 @@ public class BridgeSessionService {
      * of, which is precisely the stray that reconciliation exists to catch and that nobody wants to
      * create deliberately.
      */
-    /**
-     * Starts linking a number.
-     *
-     * <p>Refuses up front when the number already has a placed session, rather than letting it reach
-     * the unique key on the generated linked-number column. The constraint is correct and stays; the
-     * point is that a customer clicking Link twice is an ordinary thing to do and deserves a sentence
-     * instead of an integrity violation, whose text used to end up on screen.
-     */
-    public Mono<BridgeSessionSnapshot> createSession(
+    private Mono<BridgeSessionSnapshot> startLinking(
             MessageAccess access, String phone, ULong productId, String ownerService) {
 
-        return this.sessionDao
-                .getPlacedByNumber(access.getAppCode(), access.getClientCode(), phone)
-                .flatMap(existing -> Mono.<BridgeSessionSnapshot>error(new BridgeNumberAlreadyLinkedException(
-                        phone, existing.getSessionState() == null ? null : existing.getSessionState().name())))
-                .switchIfEmpty(Mono.defer(() -> FlatMapUtil.flatMapMono(
-                        () -> this.placementService.place(phone),
-                        instance -> this.createRow(access, phone, productId, ownerService, instance),
-                        (instance, row) -> this.claimAndStart(access, instance, row, phone))))
-                .contextWrite(Context.of(LogUtil.METHOD_NAME, "BridgeSessionService.createSession"));
+        return FlatMapUtil.flatMapMono(
+                () -> this.placementService.place(phone),
+                instance -> this.createRow(access, phone, productId, ownerService, instance),
+                (instance, row) -> this.claimAndStart(access, instance, row, phone));
     }
 
     private Mono<WhatsappPhoneNumber> createRow(
@@ -273,6 +317,19 @@ public class BridgeSessionService {
      * reconciliation reports the difference until it catches up.
      */
     public Mono<Void> unlink(MessageAccess access, String sessionId) {
+        return this.release(access, sessionId, "unlinked by the customer")
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "BridgeSessionService.unlink"));
+    }
+
+    /**
+     * The whole of unlinking, with the reason as a parameter.
+     *
+     * <p>Shared with the relink path, which retires a never-paired row before starting a fresh
+     * attempt on the same number and must not label that "unlinked by the customer". The reason is
+     * rendered on the numbers page and read months later out of a log, so a wrong one is a wrong
+     * answer to "what happened to this number", not a cosmetic slip.
+     */
+    private Mono<Void> release(MessageAccess access, String sessionId, String reason) {
 
         LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
 
@@ -280,7 +337,7 @@ public class BridgeSessionService {
                 .flatMap(row -> {
                     if (row.getBridgeInstanceId() == null) {
                         logger.info(
-                                "Unlinking session {}, which no instance holds. Releasing the row"
+                                "Releasing session {}, which no instance holds. Clearing the row"
                                         + " locally; there is nothing to tell.",
                                 sessionId);
                         return Mono.empty();
@@ -309,13 +366,12 @@ public class BridgeSessionService {
                                 return Mono.empty();
                             });
                 })
-                .then(this.sessionDao.releaseAssignment(
-                        sessionId, WhatsappSessionState.LOGGED_OUT, "unlinked by the customer", now))
+                .then(this.sessionDao.releaseAssignment(sessionId, WhatsappSessionState.LOGGED_OUT, reason, now))
                 // And take it off the tenant's list. Releasing the assignment alone left the row
                 // showing with a new state, which reads as the unlink having done nothing.
                 .then(this.sessionDao.deactivate(sessionId))
                 .then()
-                .contextWrite(Context.of(LogUtil.METHOD_NAME, "BridgeSessionService.unlink"));
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "BridgeSessionService.release"));
     }
 
     /**

--- a/multi/pom.xml
+++ b/multi/pom.xml
@@ -22,7 +22,7 @@
              failures (MySqlRowDescriptor AIOOBE). Fixed in 1.4.x. -->
         <r2dbc-mysql.version>1.4.2</r2dbc-mysql.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <saas-commons-version>2.0.0</saas-commons-version>
         <saas-commons-jooq-version>2.0.0</saas-commons-jooq-version>
         <saas-commons-security-version>2.0.0</saas-commons-security-version>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -22,7 +22,7 @@
              failures (MySqlRowDescriptor AIOOBE). Fixed in 1.4.x. -->
         <r2dbc-mysql.version>1.4.2</r2dbc-mysql.version>
         <spring-cloud.version>2024.0.0-RC1</spring-cloud.version>
-        <nocode-kirun-version>4.5.0</nocode-kirun-version>
+        <nocode-kirun-version>4.7.0</nocode-kirun-version>
         <saas-commons-version>2.0.0</saas-commons-version>
         <saas-commons-jooq-version>2.0.0</saas-commons-jooq-version>
         <saas-commons-security-version>2.0.0</saas-commons-security-version>

--- a/ui/src/main/java/com/fincity/saas/ui/model/PathDefinition.java
+++ b/ui/src/main/java/com/fincity/saas/ui/model/PathDefinition.java
@@ -124,9 +124,14 @@ public class PathDefinition implements Serializable, IDifferentiable<PathDefinit
 			return false;
 		}
 
+		// Each type carries exactly its own definition and not the other's. The
+		// REDIRECTION arm used to be a copy of the KIRUN_FUNCTION one, which no
+		// REDIRECTION could ever satisfy: URIPathService.setPathDefinitions has
+		// just populated redirectionDefinition and nulled kiRunFxDefinition for
+		// precisely this type, so every redirect create failed URI_INVALID_TYPE.
 		return switch (this.getUriType()) {
 			case KIRUN_FUNCTION -> (this.kiRunFxDefinition != null && this.redirectionDefinition == null);
-			case REDIRECTION -> (this.redirectionDefinition == null && this.kiRunFxDefinition != null);
+			case REDIRECTION -> (this.redirectionDefinition != null && this.kiRunFxDefinition == null);
 		};
 	}
 }


### PR DESCRIPTION
- Updated `WhatsappOutboxSweeper` to include ticket ID when sending queued messages, ensuring messages are correctly associated with the intended deal.
- Modified `WhatsappSessionService` to accept ticket ID in `sendQueued` method and updated related outbound record handling.
- Added `getWithoutWhatsappSession` method in `ProductService` to retrieve products without a WhatsApp session.
- Introduced SQL migration to add `MEDIA_ERROR` column to `entity_processor_whatsapp_messages` table for better media error tracking.
- Created `InboundWhatsappDealNameTest` to validate deal naming logic based on inbound WhatsApp messages, ensuring proper handling of profile names and fallbacks.
- Updated dependencies in `pom.xml` files to use `nocode-kirun-version` 4.7.0 for improved functionality.
- Enhanced `WhatsappSessionState` enum to include `NUMBER_MISMATCH` for better error handling during session linking.
- Added `pushName`, `sessionIsDefault`, and `backfilled` fields to `BridgeEvent` and `WhatsappInboundDispatch` for improved message context.
- Refactored `BridgeSessionService` to handle session linking more gracefully, preventing integrity violations on duplicate link attempts.
- Improved path definition validation in `PathDefinition` to ensure correct handling of URI types.