### PR TITLE
feat: Enhance draft surface functionality in AppDataService and AppDa…

### DIFF
--- a/commons-core/src/main/java/com/fincity/saas/commons/core/service/CoreMessageResourceService.java
+++ b/commons-core/src/main/java/com/fincity/saas/commons/core/service/CoreMessageResourceService.java
@@ -71,6 +71,10 @@ public class CoreMessageResourceService extends AbstractMongoMessageResourceServ
 
     public static final String STORAGE_DELETE_ALL_NOT_CONFIRMED = "storage_delete_all_not_confirmed";
 
+    public static final String FORBIDDEN_EXPLICIT_DRAFT_SURFACE = "forbidden_explicit_draft_surface";
+
+    public static final String DRAFT_COPY_SOURCE_EMPTY = "draft_copy_source_empty";
+
     public static final String STORAGE_OBJECT_ID_EXISTS = "storage_object_id_exists";
 
     public static final String NOT_ABLE_TO_CREATE_TOKEN = "not_able_to_create_token";

--- a/commons-core/src/main/java/com/fincity/saas/commons/core/service/connection/appdata/AppDataService.java
+++ b/commons-core/src/main/java/com/fincity/saas/commons/core/service/connection/appdata/AppDataService.java
@@ -252,6 +252,100 @@ public class AppDataService {
                 .contextWrite(Context.of(LogUtil.METHOD_NAME, "AppDataService.dropDraftStorageData"));
     }
 
+    /**
+     * Run one app-data operation against an explicitly named surface.
+     *
+     * Which surface a data call hits is normally ambient: {@code LogUtil.isDraft()},
+     * which the gateway sets from the resolved hostname and strips on the way in, so
+     * no caller can forge it. That is deliberate, and it stays the default -- with
+     * {@code draft == null} this returns the operation untouched.
+     *
+     * The builder is the case the ambient rule cannot serve. It runs on the live
+     * host, and still has to be able to read, seed and clear an app's draft sandbox.
+     * So it may name the surface, the same way a definition write already names its
+     * target with {@code ?draft=true}.
+     *
+     * Both values are gated, not just TRUE. Forcing {@code false} from the draft host
+     * is the mirror-image danger -- a draft-surface page writing into live data -- and
+     * one bar closes both. The bar is write access to the app, because otherwise
+     * anyone who can read a storage's rows could read its unpublished ones, and the
+     * draft hostname would stop being the credential that gates unpublished work.
+     */
+    public <T> Mono<T> onSurface(String appCode, Boolean draft, Mono<T> operation) {
+
+        if (draft == null)
+            return operation;
+
+        Mono<T> denied = this.msgService.throwMessage(
+                msg -> new GenericException(HttpStatus.FORBIDDEN, msg),
+                CoreMessageResourceService.FORBIDDEN_EXPLICIT_DRAFT_SURFACE, appCode);
+
+        return SecurityContextUtil.getUsersContextAuthentication()
+                // Only the missing-context case falls through here. An empty result
+                // from the operation itself must stay empty, which is why this sits on
+                // the authentication step rather than on the whole chain.
+                .switchIfEmpty(Mono.defer(() -> this.msgService.throwMessage(
+                        msg -> new GenericException(HttpStatus.FORBIDDEN, msg),
+                        CoreMessageResourceService.FORBIDDEN_EXPLICIT_DRAFT_SURFACE, appCode)))
+                .flatMap(ca -> this.securityService
+                        .hasWriteAccess(appCode == null ? ca.getUrlAppCode() : appCode, ca.getClientCode())
+                        .defaultIfEmpty(Boolean.FALSE)
+                        .flatMap(hasAccess -> BooleanUtil.safeValueOf(hasAccess)
+                                ? operation.contextWrite(Context.of(LogUtil.DRAFT_KEY, draft))
+                                : denied))
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "AppDataService.onSurface"));
+    }
+
+    /**
+     * Seed one storage's draft rows from its live rows.
+     *
+     * Publish promotes definitions and never promotes data, so a draft surface starts
+     * empty and stays empty. This is how a sandbox gets realistic rows.
+     *
+     * It writes into a surface the caller is not on, so it needs the same write-access
+     * bar as {@link #onSurface}, on top of the storage's own create authority. It runs
+     * with no ambient flag of its own: both namespaces are named explicitly, the same
+     * discipline dropDraftStorage and estimatedRowCount already follow.
+     */
+    public Mono<Long> copyLiveDataToDraft(String appCode, String clientCode, String storageName, Boolean replace) {
+
+        Mono<Long> mono = FlatMapUtil.flatMapMonoWithNull(
+                SecurityContextUtil::getUsersContextAuthentication,
+                ca -> Mono.just(appCode == null ? ca.getUrlAppCode() : appCode),
+                (ca, ac) -> this.clientCode(clientCode),
+                (ca, ac, cc) -> this.securityService.hasWriteAccess(ac, ca.getClientCode())
+                        .defaultIfEmpty(Boolean.FALSE)
+                        .flatMap(hasAccess -> BooleanUtil.safeValueOf(hasAccess)
+                                ? Mono.just(Boolean.TRUE)
+                                : this.msgService.throwMessage(
+                                        msg -> new GenericException(HttpStatus.FORBIDDEN, msg),
+                                        CoreMessageResourceService.FORBIDDEN_EXPLICIT_DRAFT_SURFACE, ac)),
+                (ca, ac, cc, canWrite) -> connectionService.read("appData", ac, cc, ConnectionType.APP_DATA),
+                (ca, ac, cc, canWrite, conn) -> Mono.just(
+                        this.services.get(conn == null ? DEFAULT_APP_DATA_SERVICE : conn.getConnectionSubType())),
+                (ca, ac, cc, canWrite, conn, dataService) -> getStorageWithKIRunValidation(storageName, ac, cc)
+                        .map(ObjectWithUniqueID::getObject),
+                (ca, ac, cc, canWrite, conn, dataService, storage) -> this.<Long>genericOperation(
+                        storage,
+                        (contextAuth, hasAccess) -> dataService.copyLiveToDraft(cc, conn, storage, replace),
+                        Storage::getCreateAuth,
+                        CoreMessageResourceService.FORBIDDEN_CREATE_STORAGE));
+
+        // A zero can only mean the live collection was empty, because the count is
+        // taken before anything is written, and in that case nothing was changed --
+        // the draft rows that were there are still there.
+        //
+        // Reported as a bad request rather than a successful copy of nothing, because
+        // "Copied 0 rows" reads as a bug in the copy. Deliberately NOT signalled as an
+        // empty Mono: genericOperation's own switchIfEmpty would turn that into a 403.
+        return mono.flatMap(copied -> copied < 1
+                        ? this.msgService.<Long>throwMessage(
+                                msg -> new GenericException(HttpStatus.BAD_REQUEST, msg),
+                                CoreMessageResourceService.DRAFT_COPY_SOURCE_EMPTY, storageName)
+                        : Mono.just(copied))
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "AppDataService.copyLiveDataToDraft"));
+    }
+
     public Mono<Long> estimatedRowCount(String appCode, String clientCode) {
         return this.connectionService.read("appData", appCode, clientCode, ConnectionType.APP_DATA)
                 .flatMap(conn -> this.mongoAppDataService.estimatedRowCount(conn, appCode, clientCode))

--- a/commons-core/src/main/java/com/fincity/saas/commons/core/service/connection/appdata/IAppDataService.java
+++ b/commons-core/src/main/java/com/fincity/saas/commons/core/service/connection/appdata/IAppDataService.java
@@ -60,4 +60,17 @@ public interface IAppDataService {
      * with real consequences.
      */
     Mono<Boolean> dropDraftDatabase(Connection conn, String appCode, String clientCode);
+
+    /**
+     * Seed one storage's DRAFT collection from its LIVE rows.
+     *
+     * Publish promotes definitions and never promotes data, so a draft surface
+     * starts empty and stays that way. This is how a sandbox gets realistic rows to
+     * work against. The direction is live to draft only, and it is not the inverse
+     * of publish: draft rows are never copied live.
+     *
+     * @param replace empty the draft collection first, rather than adding to it
+     * @return how many documents were written into the draft collection
+     */
+    Mono<Long> copyLiveToDraft(String clientCode, Connection conn, Storage storage, Boolean replace);
 }

--- a/commons-core/src/main/java/com/fincity/saas/commons/core/service/connection/appdata/MongoAppDataService.java
+++ b/commons-core/src/main/java/com/fincity/saas/commons/core/service/connection/appdata/MongoAppDataService.java
@@ -49,7 +49,10 @@ import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.ReplaceOptions;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.DeleteResult;
 import com.mongodb.client.result.InsertOneResult;
 import com.mongodb.reactivestreams.client.FindPublisher;
@@ -116,6 +119,12 @@ public class MongoAppDataService extends RedisPubSubAdapter<String, String> impl
     // A duplicate key can come off any unique index, so the _id one is identified by name before
     // the failure is reported as a clash on the supplied _id.
     private static final String DUPLICATE_ID_INDEX = "index: _id_";
+
+    // How many documents one bulk write carries while seeding the draft surface. Bounded
+    // so a large live collection streams rather than being collected into one list.
+    private static final int COPY_BATCH_SIZE = 500;
+
+    private static final ReplaceOptions UPSERT = new ReplaceOptions().upsert(true);
 
     private static final Map<FilterConditionOperator, String> FILTER_MATCH_OPERATOR = Map.of(
             FilterConditionOperator.EQUALS,
@@ -625,6 +634,64 @@ public class MongoAppDataService extends RedisPubSubAdapter<String, String> impl
                 .thenReturn(Boolean.TRUE)
                 .onErrorReturn(Boolean.FALSE)
                 .contextWrite(Context.of(LogUtil.METHOD_NAME, "MongoAppDataService.dropDraftDatabase"));
+    }
+
+    @Override
+    public Mono<Long> copyLiveToDraft(String clientCode, Connection conn, Storage storage, Boolean replace) {
+
+        // Both surfaces are named by writing the flag onto each accessor's own
+        // subscription, rather than reading the ambient one. Going through
+        // getCollection (instead of client.getDatabase directly) is what keeps index
+        // provisioning running on the draft side: it is memoised per
+        // (uniqueName, appCode, clientCode, draftSuffix), so the draft collection has
+        // to ask for it in its own right.
+        Mono<MongoCollection<Document>> liveCollection = this.getCollection(clientCode, conn, storage)
+                .contextWrite(Context.of(LogUtil.DRAFT_KEY, Boolean.FALSE));
+
+        Mono<MongoCollection<Document>> draftCollection = this.getCollection(clientCode, conn, storage)
+                .contextWrite(Context.of(LogUtil.DRAFT_KEY, Boolean.TRUE));
+
+        return FlatMapUtil.<MongoCollection<Document>, MongoCollection<Document>, Long, Boolean, Long>flatMapMono(
+
+                () -> liveCollection,
+
+                live -> draftCollection,
+
+                // Counted BEFORE anything is cleared. An empty source answers 0 and
+                // changes nothing: clearing the draft collection and then reporting
+                // "there was nothing to copy" would be the worst of both.
+                //
+                // 0 rather than an empty Mono, because genericOperation -- which every
+                // caller goes through -- has its own switchIfEmpty that turns an empty
+                // result into a 403. An empty here would surface as a denial.
+                (live, draft) -> Mono.from(live.countDocuments()),
+
+                // deleteMany, never drop(). A dropped collection with a warm index
+                // cache never gets its indexes back, because manageIndexes has
+                // already been memoised for this namespace.
+                (live, draft, liveCount) -> liveCount > 0 && BooleanUtil.safeValueOf(replace)
+                        ? Mono.from(draft.deleteMany(Filters.empty())).thenReturn(Boolean.TRUE)
+                        : Mono.just(Boolean.TRUE),
+
+                // _id is carried across unchanged, so relation fields on either surface
+                // keep pointing at the row they named.
+                //
+                // Upserting rather than inserting is what makes this safe to run twice
+                // and safe with replace = false: an insertMany over a draft collection
+                // that already holds any of these ids fails on the duplicate key and
+                // leaves the copy half done.
+                (live, draft, liveCount, cleared) -> liveCount < 1
+                        ? Mono.just(0L)
+                        : Flux.from(live.find())
+                                .buffer(COPY_BATCH_SIZE)
+                                .concatMap(batch -> Mono.from(draft.bulkWrite(batch.stream()
+                                                .map(doc -> (WriteModel<Document>) new ReplaceOneModel<>(
+                                                        Filters.eq(ID, doc.get(ID)), doc, UPSERT))
+                                                .toList()))
+                                        .thenReturn((long) batch.size()))
+                                .reduce(0L, Long::sum))
+
+                .contextWrite(Context.of(LogUtil.METHOD_NAME, "MongoAppDataService.copyLiveToDraft"));
     }
 
     private Flux<Document> applyQueryOnElements(

--- a/commons/src/main/java/com/fincity/saas/commons/util/LogUtil.java
+++ b/commons/src/main/java/com/fincity/saas/commons/util/LogUtil.java
@@ -29,10 +29,15 @@ public class LogUtil {
 	 *   target with an explicit ?draft=true, so a page running on the draft surface
 	 *   doing an ordinary SendData PUT is not diverted into a draft it never asked
 	 *   for.
-	 * - App DATA uses it for reads AND writes. AppDataController has no draft
-	 *   parameter on any route; a write on the draft surface goes to the draft
-	 *   database because of this flag alone. That is what makes the draft surface a
-	 *   usable sandbox rather than a read-only preview.
+	 * - App DATA uses it for reads AND writes, and this flag alone is what sends a
+	 *   draft-surface write to the draft database. That is what makes the draft
+	 *   surface a usable sandbox rather than a read-only preview.
+	 *   AppDataController's routes DO take an optional `draft` parameter, added for
+	 *   the builder: it runs on the live host and still has to read, seed and clear
+	 *   an app's sandbox rows. It writes this key into the context for one
+	 *   operation, and only for a caller with write access to the app
+	 *   (AppDataService.onSurface). Omitted, which is the normal case, the ambient
+	 *   flag governs exactly as before.
 	 *
 	 * It also crosses the message queue, carried as a field on EventQueObject. The
 	 * event listener has no inbound request to read it from, and without it a

--- a/core/src/main/java/com/fincity/saas/core/controller/connection/appdata/AppDataController.java
+++ b/core/src/main/java/com/fincity/saas/core/controller/connection/appdata/AppDataController.java
@@ -52,19 +52,45 @@ public class AppDataController {
 	public static final String PATH_ID = "{storage}/{" + PATH_VARIABLE_ID + "}";
 	public static final String PATH_QUERY = "{storage}/query";
 
+	/**
+	 * Empties a storage and keeps it.
+	 * <p>
+	 * A literal segment, not an id in disguise, and that is the point. {@code DELETE
+	 * {storage}} means "drop the collection", and it is reachable by any caller that
+	 * concatenates a row id that turns out to be absent -- which has destroyed a
+	 * collection before. A separate path can only be arrived at deliberately.
+	 */
+	public static final String PATH_ROWS = "{storage}/rows";
+
+	public static final String PATH_COPY_TO_DRAFT = "{storage}/copyToDraft";
+
 	// Here id is version's ID
 	public static final String PATH_VERSION_ID = "{storage}/version/{" + PATH_VARIABLE_ID + "}";
 
 	// Here id is the object's ID for which versions are queried
 	public static final String PATH_VERSION_ID_QUERY = "{storage}/version/{" + PATH_VARIABLE_ID + "}/query";
 
-	private static final Set<String> IGNORE_PARAMS = Set.of("page", "size", "sort", "eager", "eagerFields");
+	// Everything NOT in here is copied into the filter condition by
+	// ConditionUtil.parameterMapToMap, so a declared @RequestParam that is missing from
+	// this set also becomes a condition on a field of that name, and the request
+	// silently matches no row. `draft` has to be here for that reason.
+	private static final Set<String> IGNORE_PARAMS = Set.of("page", "size", "sort", "eager", "eagerFields", "draft");
 
 	@Autowired
 	private AppDataService service;
 
 	@Autowired
 	private CoreMessageResourceService messageResourceService;
+
+	/*
+	 * Every route below takes an optional `draft`.
+	 *
+	 * Which surface a data call hits is normally ambient, from the hostname the
+	 * gateway resolved, and that stays the default: omit the parameter and nothing
+	 * about the call changes. Naming it explicitly is for the builder, which runs on
+	 * the live host and still has to reach an app's draft sandbox. AppDataService
+	 * .onSurface holds the authorisation for that, not this controller.
+	 */
 
 	@PostMapping("{storage}")
 	public Mono<ResponseEntity<Map<String, Object>>> create(
@@ -73,9 +99,11 @@ public class AppDataController {
 			@RequestHeader String clientCode,
 			@RequestParam(required = false, defaultValue = "false") Boolean eager,
 			@RequestParam(required = false) List<String> eagerFields,
+			@RequestParam(required = false) Boolean draft,
 			@RequestBody DataObject entity) {
 
-		return this.service.create(appCode, clientCode, storageName, entity, eager, eagerFields)
+		return this.service.onSurface(appCode, draft,
+						this.service.create(appCode, clientCode, storageName, entity, eager, eagerFields))
 				.map(ResponseEntity::ok);
 	}
 
@@ -87,13 +115,15 @@ public class AppDataController {
 			@PathVariable(name = PATH_VARIABLE_ID, required = false) final String id,
 			@RequestParam(required = false, defaultValue = "false") Boolean eager,
 			@RequestParam(required = false) List<String> eagerFields,
+			@RequestParam(required = false) Boolean draft,
 			@RequestBody DataObject entity) {
 
 		if (id != null)
 			entity.getData()
 					.put("_id", id);
 
-		return this.service.update(appCode, clientCode, storageName, entity, true, eager, eagerFields)
+		return this.service.onSurface(appCode, draft,
+						this.service.update(appCode, clientCode, storageName, entity, true, eager, eagerFields))
 				.map(ResponseEntity::ok);
 	}
 
@@ -105,13 +135,15 @@ public class AppDataController {
 			@PathVariable(name = PATH_VARIABLE_ID, required = false) final String id,
 			@RequestParam(required = false, defaultValue = "false") Boolean eager,
 			@RequestParam(required = false) List<String> eagerFields,
+			@RequestParam(required = false) Boolean draft,
 			@RequestBody DataObject entity) {
 
 		if (id != null)
 			entity.getData()
 					.put("_id", id);
 
-		return this.service.update(appCode, clientCode, storageName, entity, false, eager, eagerFields)
+		return this.service.onSurface(appCode, draft,
+						this.service.update(appCode, clientCode, storageName, entity, false, eager, eagerFields))
 				.map(ResponseEntity::ok);
 
 	}
@@ -124,9 +156,11 @@ public class AppDataController {
 			@RequestParam(required = false, defaultValue = "false") Boolean eager,
 			@RequestParam(required = false) List<String> eagerFields,
 			@PathVariable(PATH_VARIABLE_ID) final String id,
+			@RequestParam(required = false) Boolean draft,
 			ServerHttpRequest request) {
 
-		return this.service.read(appCode, clientCode, storageName, id, eager, eagerFields)
+		return this.service.onSurface(appCode, draft,
+						this.service.read(appCode, clientCode, storageName, id, eager, eagerFields))
 				.map(ResponseEntity::ok);
 	}
 
@@ -138,6 +172,7 @@ public class AppDataController {
 			@RequestParam(value = "count", required = false, defaultValue = "true") Boolean count,
 			@RequestParam(required = false, defaultValue = "false") Boolean eager,
 			@RequestParam(required = false) List<String> eagerFields,
+			@RequestParam(required = false) Boolean draft,
 			Pageable pageable,
 			ServerHttpRequest request) {
 
@@ -161,7 +196,8 @@ public class AppDataController {
 				.setEager(eager)
 				.setEagerFields(eagerFields);
 
-		return this.service.readPage(appCode, clientCode, storageName, query)
+		return this.service.onSurface(appCode, draft,
+						this.service.readPage(appCode, clientCode, storageName, query))
 				.map(ResponseEntity::ok);
 	}
 
@@ -170,18 +206,22 @@ public class AppDataController {
 			@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
 			@RequestHeader String appCode,
 			@RequestHeader String clientCode,
+			@RequestParam(required = false) Boolean draft,
 			@RequestBody Query query) {
 
-		return this.service.readPage(appCode, clientCode, storageName, query)
+		return this.service.onSurface(appCode, draft,
+						this.service.readPage(appCode, clientCode, storageName, query))
 				.map(ResponseEntity::ok);
 	}
 
 	@DeleteMapping(PATH_ID)
 	public Mono<ResponseEntity<Boolean>> delete(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
 			@RequestHeader String appCode, @RequestHeader String clientCode,
-			@PathVariable(PATH_VARIABLE_ID) final String id) {
+			@PathVariable(PATH_VARIABLE_ID) final String id,
+			@RequestParam(required = false) Boolean draft) {
 
-		return this.service.delete(appCode, clientCode, storageName, id)
+		return this.service.onSurface(appCode, draft,
+						this.service.delete(appCode, clientCode, storageName, id))
 				.map(ResponseEntity::ok);
 	}
 
@@ -197,21 +237,75 @@ public class AppDataController {
 	@DeleteMapping("{storage}")
 	public Mono<ResponseEntity<Boolean>> deleteStorage(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
 			@RequestHeader String appCode, @RequestHeader String clientCode,
-			@RequestParam(required = false, defaultValue = "false") Boolean deleteAll) {
+			@RequestParam(required = false, defaultValue = "false") Boolean deleteAll,
+			@RequestParam(required = false) Boolean draft) {
 
 		if (!Boolean.TRUE.equals(deleteAll))
 			return this.messageResourceService.throwMessage(
 					msg -> new GenericException(HttpStatus.BAD_REQUEST, msg),
 					CoreMessageResourceService.STORAGE_DELETE_ALL_NOT_CONFIRMED, storageName);
 
-		return this.service.deleteStorage(appCode, clientCode, storageName)
+		return this.service.onSurface(appCode, draft,
+						this.service.deleteStorage(appCode, clientCode, storageName))
+				.map(ResponseEntity::ok);
+	}
+
+	/**
+	 * Deletes every row and keeps the storage.
+	 * <p>
+	 * Distinct from {@link #deleteStorage} in what survives: the collection stays, and
+	 * so does its {@code _version} history. What it does NOT do is run the single-row
+	 * delete path -- no {@code BEFORE_DELETE}/{@code AFTER_DELETE} triggers, no
+	 * {@code Delete} events, and no relation {@code deleteConstraint} checks, so a
+	 * RESTRICT does not stop it and a CASCADE does not follow it. Anything offering
+	 * this to a person has to say so.
+	 *
+	 * @param dryRun count the rows instead of deleting them
+	 */
+	@DeleteMapping(PATH_ROWS)
+	public Mono<ResponseEntity<Long>> deleteAllRows(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
+			@RequestHeader String appCode, @RequestHeader String clientCode,
+			@RequestParam(required = false, defaultValue = "false") Boolean deleteAll,
+			@RequestParam(required = false, defaultValue = "false") Boolean dryRun,
+			@RequestParam(required = false) Boolean draft) {
+
+		if (!Boolean.TRUE.equals(deleteAll) && !Boolean.TRUE.equals(dryRun))
+			return this.messageResourceService.throwMessage(
+					msg -> new GenericException(HttpStatus.BAD_REQUEST, msg),
+					CoreMessageResourceService.STORAGE_DELETE_ALL_NOT_CONFIRMED, storageName);
+
+		// A null condition is a match-all in MongoAppDataService.filter, which is what
+		// makes deleteByFilter the whole-collection delete without a second code path.
+		return this.service.onSurface(appCode, draft,
+						this.service.deleteByFilter(appCode, clientCode, storageName, new Query(), dryRun))
+				.map(ResponseEntity::ok);
+	}
+
+	/**
+	 * Copies this storage's LIVE rows into its DRAFT rows.
+	 * <p>
+	 * Publish promotes definitions and never promotes data, so a draft surface starts
+	 * empty. This is how a sandbox gets realistic rows to work against. It takes no
+	 * {@code draft} parameter because it names both surfaces itself, and it only goes
+	 * one way: draft rows are never copied live.
+	 *
+	 * @param replace empty the draft rows first, rather than overlaying onto them
+	 * @return how many rows were written
+	 */
+	@PostMapping(PATH_COPY_TO_DRAFT)
+	public Mono<ResponseEntity<Long>> copyToDraft(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
+			@RequestHeader String appCode, @RequestHeader String clientCode,
+			@RequestParam(required = false, defaultValue = "true") Boolean replace) {
+
+		return this.service.copyLiveDataToDraft(appCode, clientCode, storageName, replace)
 				.map(ResponseEntity::ok);
 	}
 
 	@GetMapping("download/{fileType}/{storage}")
 	public Mono<Void> downloadContent(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
 			@RequestHeader String appCode, @RequestHeader String clientCode,
-			@PathVariable(name = "fileType") DataFileType fileType, ServerHttpRequest request,
+			@PathVariable(name = "fileType") DataFileType fileType,
+			@RequestParam(required = false) Boolean draft, ServerHttpRequest request,
 			ServerHttpResponse response) {
 
 		MultiValueMap<String, String> params = request.getQueryParams();
@@ -227,16 +321,19 @@ public class AppDataController {
 				.setCondition(ConditionUtil.parameterMapToMap(map))
 				.setSize(1000);
 
-		return this.service.downloadData(appCode, clientCode, storageName, query, fileType, response);
+		return this.service.onSurface(appCode, draft,
+				this.service.downloadData(appCode, clientCode, storageName, query, fileType, response));
 	}
 
 	@PostMapping("download/{fileType}/{storage}")
 	public Mono<Void> downloadContent(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
 			@RequestHeader String appCode, @RequestHeader String clientCode,
-			@PathVariable(name = "fileType", required = false) DataFileType fileType, @RequestBody Query query,
+			@PathVariable(name = "fileType", required = false) DataFileType fileType,
+			@RequestParam(required = false) Boolean draft, @RequestBody Query query,
 			ServerHttpResponse response) {
 
-		return this.service.downloadData(appCode, clientCode, storageName, query, fileType, response);
+		return this.service.onSurface(appCode, draft,
+				this.service.downloadData(appCode, clientCode, storageName, query, fileType, response));
 	}
 
 	@GetMapping("template/{storage}")
@@ -259,17 +356,19 @@ public class AppDataController {
 	public Mono<ResponseEntity<Boolean>> uploadData(@PathVariable(PATH_VARIABLE_STORAGE) final String storageName,
 			@RequestHeader String appCode, @RequestHeader String clientCode,
 			@RequestParam(value = "type", required = false) DataFileType fileType,
+			@RequestParam(required = false) Boolean draft,
 			@RequestPart(value = "file") Mono<FilePart> filePartMono) {
 
-		return FlatMapUtil.flatMapMono(
+		return this.service.onSurface(appCode, draft, FlatMapUtil.flatMapMono(
 
-				() -> filePartMono,
+						() -> filePartMono,
 
-				filePart -> Mono
-						.just(fileType == null ? DataFileType.getFileTypeFromExtension(filePart.filename()) : fileType),
+						filePart -> Mono.just(fileType == null
+								? DataFileType.getFileTypeFromExtension(filePart.filename())
+								: fileType),
 
-				(filePart, type) -> this.service.uploadData(appCode, clientCode, storageName, type, filePart)
-						.map(ResponseEntity::ok))
+						(filePart, type) -> this.service.uploadData(appCode, clientCode, storageName, type, filePart)
+								.map(ResponseEntity::ok)))
 
 				.contextWrite(Context.of(LogUtil.METHOD_NAME, "AppDataController.uploadData"));
 	}
@@ -277,9 +376,11 @@ public class AppDataController {
 	@GetMapping(PATH_VERSION_ID)
 	public Mono<ResponseEntity<Map<String, Object>>> getVersion(
 			@PathVariable(PATH_VARIABLE_STORAGE) final String storageName, @RequestHeader String appCode,
-			@RequestHeader String clientCode, @PathVariable(PATH_VARIABLE_ID) final String versionId) {
+			@RequestHeader String clientCode, @PathVariable(PATH_VARIABLE_ID) final String versionId,
+			@RequestParam(required = false) Boolean draft) {
 
-		return this.service.readVersion(appCode, clientCode, storageName, versionId)
+		return this.service.onSurface(appCode, draft,
+						this.service.readVersion(appCode, clientCode, storageName, versionId))
 				.map(ResponseEntity::ok);
 	}
 
@@ -287,9 +388,11 @@ public class AppDataController {
 	public Mono<ResponseEntity<Page<Map<String, Object>>>> findVersions(
 			@PathVariable(PATH_VARIABLE_STORAGE) final String storageName, @RequestHeader String appCode,
 			@RequestHeader String clientCode, @PathVariable(PATH_VARIABLE_ID) final String versionId,
+			@RequestParam(required = false) Boolean draft,
 			@RequestBody Query query) {
 
-		return this.service.readPageVersion(appCode, clientCode, storageName, versionId, query)
+		return this.service.onSurface(appCode, draft,
+						this.service.readPageVersion(appCode, clientCode, storageName, versionId, query))
 				.map(ResponseEntity::ok);
 	}
 }

--- a/core/src/main/resources/messages_en.properties
+++ b/core/src/main/resources/messages_en.properties
@@ -54,6 +54,8 @@ invalid_relation_data=Invalid relation data in the field $ with data $
 cannot_delete_storage_with_restrict=Following objects exists and cannot be deleted: $
 storage_delete_all_not_confirmed=Deleting every row of $ needs deleteAll=true. If you meant to delete one row, the row id is missing from the URL.
 storage_object_id_exists=A row with _id $ already exists in $. Remove the _id from the data to store it as a new row, or update the existing row instead.
+forbidden_explicit_draft_surface=Naming the data surface needs write access to the application $. Without it, a data call reads and writes whichever surface its hostname resolves to.
+draft_copy_source_empty=Storage $ has no live rows to copy into the draft surface.
 transport_error=Error while $ transport : $
 connection_not_available=Connection $ not available
 unable_to_execute=Unable to execute function $.$ with parameters $

--- a/core/src/test/java/com/fincity/saas/core/integration/AppDataSurfaceIntegrationTest.java
+++ b/core/src/test/java/com/fincity/saas/core/integration/AppDataSurfaceIntegrationTest.java
@@ -1,0 +1,414 @@
+package com.fincity.saas.core.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+
+import com.fincity.saas.commons.core.document.Storage;
+import com.fincity.saas.commons.core.model.DataObject;
+import com.fincity.saas.commons.core.service.connection.appdata.AppDataService;
+import com.fincity.saas.commons.exeception.GenericException;
+import com.fincity.saas.commons.model.Query;
+import com.fincity.saas.commons.security.jwt.ContextAuthentication;
+import com.mongodb.reactivestreams.client.MongoClient;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Naming the data surface, clearing rows without dropping the storage, and
+ * seeding draft rows from live.
+ *
+ * These three go together because they are the builder's side of the draft data
+ * surface. The surface is otherwise ambient -- decided by the hostname the
+ * gateway resolved -- and the builder runs on the live host, so without an
+ * explicit opt-in it can neither see nor manage an app's sandbox rows at all.
+ *
+ * The assertions go against Mongo directly wherever the claim is about *where*
+ * something landed. Reading it back through the same accessor that decided would
+ * prove nothing.
+ */
+@DisplayName("App data surface, clear and seed")
+class AppDataSurfaceIntegrationTest extends AbstractIntegrationTest {
+
+    private static final String STORAGE_NAME = "surfaceStorage";
+    private static final String UNIQUE_NAME = "testapp_system_surfacestorage";
+    private static final String VERSION_COLLECTION = UNIQUE_NAME + "_version";
+
+    private static final String LIVE_DB = SYSTEM + "_" + APP_CODE;
+    private static final String DRAFT_DB = SYSTEM + "_" + APP_CODE + "_draft";
+
+    @Autowired
+    private AppDataService appDataService;
+
+    @Autowired
+    private MongoClient mongoClient;
+
+    /**
+     * App data lives in `<client>_<app>` and its `_draft` sibling, neither of
+     * which the base class cleanup can see -- that only drops collections in the
+     * Spring Data database. Without this, rows from one test survive into the next
+     * and every isolation assertion here passes or fails on ordering.
+     */
+    @BeforeEach
+    @AfterEach
+    void dropAppDataDatabases() {
+        Mono.from(this.mongoClient.getDatabase(LIVE_DB).drop()).block();
+        Mono.from(this.mongoClient.getDatabase(DRAFT_DB).drop()).block();
+        // Index provisioning is memoised per (storage, app, client, surface); a
+        // dropped collection with a warm cache would never get its indexes back.
+        this.cacheService.evictAllCaches().block();
+    }
+
+    private void storedStorage(boolean versioned) {
+
+        Storage storage = new Storage();
+        storage.setName(STORAGE_NAME)
+                .setAppCode(APP_CODE)
+                .setClientCode(SYSTEM)
+                .setVersion(1);
+
+        Map<String, Object> titleField = new HashMap<>();
+        titleField.put("type", "STRING");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("title", titleField);
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("name", "SurfaceStorage");
+        schema.put("type", "OBJECT");
+        schema.put("properties", properties);
+
+        storage.setSchema(schema);
+        storage.setIsVersioned(versioned);
+        storage.setUniqueName(UNIQUE_NAME);
+        this.insertRaw(storage);
+    }
+
+    private <T> T asClient(Mono<T> mono) {
+        ContextAuthentication ca = this.authFor(SYSTEM, allAuthoritiesFor("Storage"));
+        return mono.contextWrite(ReactiveSecurityContextHolder.withAuthentication(ca)).block();
+    }
+
+    private <T> T asDraftClient(Mono<T> mono) {
+        ContextAuthentication ca = this.authFor(SYSTEM, allAuthoritiesFor("Storage"));
+        return this.onDraftSurface(mono.contextWrite(ReactiveSecurityContextHolder.withAuthentication(ca))).block();
+    }
+
+    private DataObject row(String title) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("title", title);
+        return new DataObject().setData(data);
+    }
+
+    private List<Document> documentsIn(String database, String collection) {
+        return Flux.from(this.mongoClient.getDatabase(database).getCollection(collection).find())
+                .collectList()
+                .block();
+    }
+
+    private List<String> collectionsIn(String database) {
+        return Flux.from(this.mongoClient.getDatabase(database).listCollectionNames())
+                .collectList()
+                .block();
+    }
+
+    private Query all() {
+        return new Query().setPage(0).setSize(50);
+    }
+
+    // ── naming the surface ───────────────────────────────────────────────────
+
+    @Test
+    @Timeout(60)
+    @DisplayName("draft = true reads the draft rows from a caller on the live surface")
+    void explicitDraftReadsDraftRows() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("live row"), false, null));
+        asDraftClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("draft row"), false, null));
+
+        // No onDraftSurface here: this is the builder's position exactly -- ambient
+        // flag false, surface named on the call.
+        var drafted = asClient(appDataService.onSurface(APP_CODE, Boolean.TRUE,
+                appDataService.readPage(APP_CODE, SYSTEM, STORAGE_NAME, all())));
+
+        assertNotNull(drafted);
+        assertEquals(1, drafted.getContent().size());
+        assertEquals("draft row", drafted.getContent().getFirst().get("title"));
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("draft = false forces live even when the ambient flag says draft")
+    void explicitLiveOverridesAmbientDraft() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("live row"), false, null));
+        asDraftClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("draft row"), false, null));
+
+        // The mirror-image case, and the reason both values are gated rather than
+        // only TRUE: a caller on the draft surface asking for live.
+        var live = asDraftClient(appDataService.onSurface(APP_CODE, Boolean.FALSE,
+                appDataService.readPage(APP_CODE, SYSTEM, STORAGE_NAME, all())));
+
+        assertNotNull(live);
+        assertEquals(1, live.getContent().size());
+        assertEquals("live row", live.getContent().getFirst().get("title"));
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("no draft parameter leaves the ambient surface alone")
+    void absentParameterKeepsAmbientSurface() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("live row"), false, null));
+        asDraftClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("draft row"), false, null));
+
+        var ambient = asDraftClient(appDataService.onSurface(APP_CODE, null,
+                appDataService.readPage(APP_CODE, SYSTEM, STORAGE_NAME, all())));
+
+        assertNotNull(ambient);
+        assertEquals("draft row", ambient.getContent().getFirst().get("title"),
+                "a null draft parameter must not disturb the hostname's answer");
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("naming the surface without write access on the app is forbidden")
+    void namingSurfaceNeedsWriteAccess() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        // Read authority on the storage is untouched. What is withdrawn is write
+        // access to the APP, which is the bar that keeps the draft hostname a
+        // credential rather than a formality.
+        Mockito.when(this.feignSecurityService.hasWriteAccess(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Mono.just(Boolean.FALSE));
+
+        GenericException ex = assertThrows(GenericException.class, () -> asClient(appDataService.onSurface(
+                APP_CODE, Boolean.TRUE, appDataService.readPage(APP_CODE, SYSTEM, STORAGE_NAME, all()))));
+
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("a never-written draft collection reads as empty, not as a denial")
+    void unwrittenDraftReadsEmpty() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("live row"), false, null));
+
+        // Most apps have no draft database at all, so this is the normal first
+        // answer the Data view gets after switching to the sandbox. It has to be
+        // distinguishable from "you may not look".
+        var drafted = asClient(appDataService.onSurface(APP_CODE, Boolean.TRUE,
+                appDataService.readPage(APP_CODE, SYSTEM, STORAGE_NAME, all())));
+
+        assertNotNull(drafted);
+        assertTrue(drafted.getContent().isEmpty());
+    }
+
+    // ── clearing rows ────────────────────────────────────────────────────────
+
+    @Test
+    @Timeout(60)
+    @DisplayName("clearing rows empties the collection and keeps it, with its history")
+    void clearKeepsCollectionAndHistory() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(true);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("one"), false, null));
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("two"), false, null));
+
+        assertEquals(2, documentsIn(LIVE_DB, UNIQUE_NAME).size());
+        assertEquals(2, documentsIn(LIVE_DB, VERSION_COLLECTION).size(),
+                "a versioned storage records one version row per create");
+
+        Long deleted = asClient(appDataService.deleteByFilter(APP_CODE, SYSTEM, STORAGE_NAME, new Query(), false));
+
+        assertEquals(2L, deleted);
+        assertTrue(documentsIn(LIVE_DB, UNIQUE_NAME).isEmpty());
+
+        // This is the whole difference from deleteStorage, which drops both.
+        assertTrue(collectionsIn(LIVE_DB).contains(UNIQUE_NAME),
+                "the collection must survive a clear, or its indexes go with it");
+        assertEquals(2, documentsIn(LIVE_DB, VERSION_COLLECTION).size(),
+                "clearing rows must not destroy the history of the rows that were there");
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("a dry run counts the rows and deletes nothing")
+    void dryRunCountsOnly() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("one"), false, null));
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("two"), false, null));
+
+        Long counted = asClient(appDataService.deleteByFilter(APP_CODE, SYSTEM, STORAGE_NAME, new Query(), true));
+
+        assertEquals(2L, counted);
+        assertEquals(2, documentsIn(LIVE_DB, UNIQUE_NAME).size(), "a dry run must not delete");
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("clearing the draft surface leaves live rows alone")
+    void clearOnDraftLeavesLive() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("live row"), false, null));
+        asDraftClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("draft row"), false, null));
+
+        Long deleted = asClient(appDataService.onSurface(APP_CODE, Boolean.TRUE,
+                appDataService.deleteByFilter(APP_CODE, SYSTEM, STORAGE_NAME, new Query(), false)));
+
+        assertEquals(1L, deleted);
+        assertTrue(documentsIn(DRAFT_DB, UNIQUE_NAME).isEmpty());
+        assertEquals(1, documentsIn(LIVE_DB, UNIQUE_NAME).size(),
+                "clearing the sandbox must never reach live data");
+    }
+
+    // ── seeding draft from live ──────────────────────────────────────────────
+
+    @Test
+    @Timeout(60)
+    @DisplayName("copying live to draft preserves ids and leaves live untouched")
+    void copyPreservesIdsAndKeepsLive() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("one"), false, null));
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("two"), false, null));
+
+        Long copied = asClient(appDataService.copyLiveDataToDraft(APP_CODE, SYSTEM, STORAGE_NAME, true));
+
+        assertEquals(2L, copied);
+
+        List<Document> live = documentsIn(LIVE_DB, UNIQUE_NAME);
+        List<Document> draft = documentsIn(DRAFT_DB, UNIQUE_NAME);
+
+        assertEquals(2, live.size(), "the source must be untouched");
+        assertEquals(2, draft.size());
+
+        // Ids carried across is what keeps relation fields pointing at the right row
+        // on both surfaces.
+        assertEquals(live.stream().map(d -> d.get("_id")).sorted(idOrder()).toList(),
+                draft.stream().map(d -> d.get("_id")).sorted(idOrder()).toList(),
+                "draft rows must keep the ids their live originals had");
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("copying with replace empties the draft rows that were there first")
+    void copyWithReplaceClearsDraftFirst() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("live only"), false, null));
+        asDraftClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("sandbox scratch"), false, null));
+
+        asClient(appDataService.copyLiveDataToDraft(APP_CODE, SYSTEM, STORAGE_NAME, true));
+
+        List<Document> draft = documentsIn(DRAFT_DB, UNIQUE_NAME);
+        assertEquals(1, draft.size(), "the pre-existing sandbox row must be gone, not added to");
+        assertEquals("live only", draft.getFirst().get("title"));
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("copying twice is idempotent rather than a duplicate key failure")
+    void copyTwiceIsIdempotent() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("one"), false, null));
+
+        // replace = false is the case an insertMany would fail on: the ids are
+        // already there. It upserts instead.
+        asClient(appDataService.copyLiveDataToDraft(APP_CODE, SYSTEM, STORAGE_NAME, false));
+        Long second = asClient(appDataService.copyLiveDataToDraft(APP_CODE, SYSTEM, STORAGE_NAME, false));
+
+        assertEquals(1L, second);
+        assertEquals(1, documentsIn(DRAFT_DB, UNIQUE_NAME).size());
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("copying with no live rows is refused and changes nothing")
+    void copyWithEmptySourceChangesNothing() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asDraftClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("sandbox scratch"), false, null));
+
+        GenericException ex = assertThrows(GenericException.class,
+                () -> asClient(appDataService.copyLiveDataToDraft(APP_CODE, SYSTEM, STORAGE_NAME, true)));
+
+        assertEquals(HttpStatus.BAD_REQUEST, ex.getStatusCode());
+
+        // The point of counting the source before clearing the destination: a
+        // refusal that had already emptied the sandbox would be the worst of both.
+        assertEquals(1, documentsIn(DRAFT_DB, UNIQUE_NAME).size(),
+                "a refused copy must not have cleared the draft rows");
+    }
+
+    @Test
+    @Timeout(60)
+    @DisplayName("copying to draft without write access on the app is forbidden")
+    void copyNeedsWriteAccess() {
+
+        setInheritance(List.of(SYSTEM));
+        storedStorage(false);
+
+        asClient(appDataService.create(APP_CODE, SYSTEM, STORAGE_NAME, row("one"), false, null));
+
+        Mockito.when(this.feignSecurityService.hasWriteAccess(Mockito.anyString(), Mockito.anyString()))
+                .thenReturn(Mono.just(Boolean.FALSE));
+
+        GenericException ex = assertThrows(GenericException.class,
+                () -> asClient(appDataService.copyLiveDataToDraft(APP_CODE, SYSTEM, STORAGE_NAME, true)));
+
+        assertEquals(HttpStatus.FORBIDDEN, ex.getStatusCode());
+    }
+
+    private static java.util.Comparator<Object> idOrder() {
+        return java.util.Comparator.comparing(Object::toString);
+    }
+}

--- a/docs/draft-surface-handoff.md
+++ b/docs/draft-surface-handoff.md
@@ -18,12 +18,21 @@ Two separate mechanisms, deliberately not one:
 |---|---|---|
 | **Which surface a read sees** | the ambient `x-draft` flag | set by the gateway from the resolved hostname, never by a caller |
 | **Where a DEFINITION write goes** | an explicit `?draft=true` on the call | the caller names its target |
-| **Where a DATA write goes** | the ambient flag | `AppDataController` has no draft parameter |
+| **Where a DATA write goes** | the ambient flag, or an explicit `?draft=` | ambient by default; the parameter is builder-only |
 
 Keeping definition writes explicit matters: a page running *on* the draft surface doing an ordinary
 `UIEngine.SendData` PUT must not be silently diverted into a draft it never asked for. App data is
 the deliberate exception, and it is what makes the draft surface a usable sandbox rather than a
 read-only preview.
+
+**App data now has a second, narrow door.** Every `AppDataController` row route takes an optional
+`draft` parameter, and `AppDataService.onSurface` honours it for one operation. Omitted -- the normal
+case, and every pre-existing caller -- nothing changes and the ambient flag governs. It exists
+because the builder runs on the LIVE host and still has to read, seed and clear an app's sandbox
+rows; the ambient rule cannot serve that, and the draft host has no row browser.
+Both values are gated on `hasWriteAccess` for the app, not only `true`: forcing `false` from a draft
+host is the mirror-image danger, a draft-surface page writing into live data. It is an ADDITION to
+the storage's own `readAuth`/`createAuth`/`updateAuth`/`deleteAuth`, never a replacement.
 
 ### The write matrix
 
@@ -40,6 +49,10 @@ read-only preview.
 | `POST /api/ui/publish/app/{appCode}` | Publishes all of it |
 | `GET`/`POST /api/core/publish/app/{appCode}` | The same two routes for core objects, same gate |
 | `DELETE /api/ui/pages/{id}` | Deletes the object **and its draft**. Nothing is left pending |
+| `POST /api/core/data/{storage}/query?draft=true` | Reads the DRAFT rows from a caller on the live host. Needs write access to the app |
+| `DELETE /api/core/data/{storage}/rows?deleteAll=true` | Deletes every row and **keeps** the collection and its `_version` history. `&dryRun=true` counts instead. Takes `&draft=` |
+| `DELETE /api/core/data/{storage}?deleteAll=true` | Unchanged, and still the DROP: the collection and its history both go |
+| `POST /api/core/data/{storage}/copyToDraft?replace=true` | Copies the storage's LIVE rows into its DRAFT rows, ids intact. One way only |
 
 `publishAll` reports every draft it looked at, including ones it could not ship. An object whose
 document has gone missing under its draft comes back as `published: false` with an `error`, not as a
@@ -242,6 +255,13 @@ generator scripts, not through the page editor or MCP, or they get reverted.
   `GET /api/ui/publish/app/{appCode}/pending`.
 - A way to mint and copy the draft link, from `POST /api/security/clienturls/draft`.
 
+**Done since**, in `appbuilder_SYSTEM/tools/ws_data.py` (the storage Data view on `workspace`):
+a Live/Draft switch on the row browser, "Clear rows" and "Copy live rows here", both behind a
+confirm that names the surface. Its invariants are checked by `draft_check.py` and the whole
+sequence is driven in a browser by `data_flow_drive.py`. The Data view is otherwise unscripted, so
+`ws_data.py` patches `workspace` by naming what it touches and must never replace
+`componentDefinition` or `eventFunctions` wholesale.
+
 ### 2. `nocode-ui` client: mostly done, one thing left
 
 Already done: `globalThis.isDraftMode` (read from the server-stamped `data-draft` attribute, not
@@ -283,8 +303,10 @@ so it is carried the only way that reaches all of them, as **a second kind of ho
 - The two surfaces and the read/write split (the table at the top of this file).
 - Publish semantics: definitions promote, draft data is kept and never promoted.
 - That draft data is real data in a real database, dropped only when the storage definition or the
-  app is deleted. There is no age-based expiry and no manual clear action; a long-lived draft surface
-  accumulates rows and bills for them.
+  app is deleted, or cleared by hand one storage at a time. There is no age-based expiry, so a
+  long-lived draft surface accumulates rows and bills for them.
+- That the builder can browse, seed and clear draft rows without leaving the live host, and how the
+  `draft` parameter on the data routes differs from the ambient flag.
 - The draft link is a bearer credential: anyone with the URL sees unpublished work. Rotating
   revokes it.
 
@@ -405,11 +427,16 @@ metering window.
 
 ### How a write lands there
 
-Purely ambient, from `LogUtil.isDraft()` in the Reactor Context. This is the part that surprises
-people: **`AppDataController` has no `draft` parameter on any of its routes.** A write on the draft
-surface goes to the draft database because of the ambient flag alone. That is the deliberate
-exception to the rule stated at the top of this file, and it is what makes the surface a usable
-sandbox instead of a read-only preview.
+Ambient by default, from `LogUtil.isDraft()` in the Reactor Context. This is the part that
+surprises people: a write on the draft surface goes to the draft database because of the ambient
+flag alone, with nothing in the request saying so. That is the deliberate exception to the rule
+stated at the top of this file, and it is what makes the surface a usable sandbox instead of a
+read-only preview.
+
+Since then the routes have gained an **optional** `draft` parameter, honoured by
+`AppDataService.onSurface` for one operation and only for a caller with write access to the app.
+Omitted, everything above still holds exactly. It exists for the builder, which is on the live host
+and has to reach the sandbox; see the top of this file.
 
 The flag is set only by the gateway from the resolved hostname, and the gateway strips any inbound
 value first, so a caller cannot forge it. It reaches queue consumers as a field on the message
@@ -419,9 +446,15 @@ inbound request to read a context from.
 ### Publish does not promote data
 
 Definitions promote; **draft rows stay where they are**. There is no "copy my draft rows live"
-operation, and none was asked for. The two data sets are independent from the moment the draft
+operation, and there should not be. The two data sets are independent from the moment the draft
 surface is first written to. A draft surface is therefore not a rehearsal of a data migration, and
 should not be described as one.
+
+The OTHER direction does exist now: `POST /api/core/data/{storage}/copyToDraft` copies a storage's
+live rows into its draft rows, `_id`s intact so relation fields keep pointing at the right row. It
+is a way to start a sandbox from realistic data, not a promotion, and it is deliberately one way.
+It upserts rather than inserts, so it is safe to run twice, and it counts the source BEFORE clearing
+the destination -- a refusal that had already emptied the sandbox would be the worst of both.
 
 ### Metering
 
@@ -472,8 +505,11 @@ Two implementation notes that matter if you call these from anywhere new:
   Mono is empty and nothing drops, silently.** It is only ever called from inside `StorageService`'s
   authenticated chain today. It is not safe to call from a scheduled job as written.
 
-**What is retained.** There is no age-based expiry and no manual "clear draft data" action. A draft
-surface that is never deleted keeps its rows indefinitely, and meters them.
+**What is retained.** There is still no age-based expiry, so a draft surface that is never deleted
+keeps its rows indefinitely and meters them. There IS a manual clear now:
+`DELETE /api/core/data/{storage}/rows?deleteAll=true&draft=true`, per storage, surfaced in the
+builder's storage Data view. It empties the collection and keeps it, which is the difference from
+`DELETE {storage}`. Nothing clears a whole draft database short of deleting the app.
 
 ### Test coverage of the deletion paths, and its gaps
 


### PR DESCRIPTION
…taController

- Implemented copyLiveToDraft method in MongoAppDataService to copy live rows to draft while preserving IDs.
- Added optional draft parameter to AppDataController routes to allow explicit surface selection for data operations.
- Introduced new DELETE endpoint to clear all rows while retaining the storage collection and its version history.
- Updated LogUtil documentation to clarify the use of the draft parameter.
- Added integration tests for draft surface operations, ensuring proper functionality and access control.
- Enhanced documentation to reflect changes in draft surface handling and new API endpoints.