### PR TITLE
feat: Enhance ClientUrlService to support pagination and filtering

### DIFF
--- a/commons-security/src/main/java/com/fincity/saas/commons/security/feign/IFeignSecurityService.java
+++ b/commons-security/src/main/java/com/fincity/saas/commons/security/feign/IFeignSecurityService.java
@@ -29,6 +29,7 @@ import com.fincity.saas.commons.security.model.UsersListRequest;
 
 import reactivefeign.spring.config.ReactiveFeignClient;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple3;
 import reactor.util.function.Tuple2;
 
 @ReactiveFeignClient(name = "security")
@@ -148,6 +149,20 @@ public interface IFeignSecurityService {
 
     @GetMapping("${security.feign.dependencies:/api/security/applications/internal/dependencies}")
     Mono<List<String>> getDependencies(@RequestParam String appCode);
+
+    /**
+     * Which client and app a hostname serves, plus the surface type:
+     * {@code (clientCode, appCode, urlType)}. An unknown host answers
+     * {@code ("SYSTEM", "nothing", "LIVE")} rather than empty, so "nothing" is the
+     * sentinel for "no ClientUrl row", not an error.
+     * <p>
+     * Unauthenticated by design: this is the gateway's per-request host resolver.
+     * Mirrors {@code IFeignSecurityClient.getClientCodeNType} in the gateway; the two
+     * must stay in step.
+     */
+    @GetMapping("${security.feign.getClientNAppCodeNType:/api/security/clients/internal/getClientNAppCodeNType}")
+    Mono<Tuple3<String, String, String>> getClientNAppCodeNType(@RequestParam String scheme,
+            @RequestParam String host, @RequestParam String port);
 
     @GetMapping("${security.feign.getAppUrl:/api/security/clienturls/internal/applications/property/url}")
     Mono<String> getAppUrl(@RequestParam String appCode, @RequestParam(required = false) String clientCode);

--- a/files/src/main/java/com/modlix/saas/files/dao/FileSystemDao.java
+++ b/files/src/main/java/com/modlix/saas/files/dao/FileSystemDao.java
@@ -34,6 +34,7 @@ import com.modlix.saas.files.jooq.enums.FilesFileSystemType;
 import static com.modlix.saas.files.jooq.tables.FilesFileSystem.FILES_FILE_SYSTEM;
 
 import com.modlix.saas.files.jooq.tables.records.FilesFileSystemRecord;
+import com.modlix.saas.files.util.FileNameUtil;
 import com.modlix.saas.files.model.FileDetail;
 import com.modlix.saas.files.model.FilesPage;
 
@@ -348,6 +349,8 @@ public class FileSystemDao {
             name = path.substring(index + 1);
         }
 
+        FileNameUtil.validate(name);
+
         var parentId = this.getFolderId(fileSystemType, clientCode, parentPath);
         var updatedCreated = false;
 
@@ -420,6 +423,8 @@ public class FileSystemDao {
         String parentPath = lastIndex == -1 ? null : resourcePath.substring(0, lastIndex);
         String name = lastIndex == -1 ? resourcePath : resourcePath.substring(lastIndex + 1);
 
+        FileNameUtil.validate(name);
+
         var parentId = parentPath == null ? Optional.<ULong>empty()
                 : this.getFolderId(fileSystemType, clientCode, parentPath);
 
@@ -467,6 +472,7 @@ public class FileSystemDao {
                 }
 
                 sb.append(part);
+                FileNameUtil.validate(part);
                 if (!nodeMap.containsKey(sb.toString())) {
                     nodeMap.put(sb.toString(),
                             new Node(null, part, sb.toString(), parentNode));

--- a/files/src/main/java/com/modlix/saas/files/util/FileNameUtil.java
+++ b/files/src/main/java/com/modlix/saas/files/util/FileNameUtil.java
@@ -1,0 +1,80 @@
+package com.modlix.saas.files.util;
+
+import java.util.Set;
+
+import org.springframework.http.HttpStatus;
+
+import com.modlix.saas.commons2.exception.GenericException;
+
+/**
+ * One gate for every name that becomes a row in {@code files_file_system}.
+ *
+ * The file tree is a database table, not a filesystem, so it will happily store
+ * whatever segment a URL hands it -- and every files/assets page builds its
+ * create-directory URL as {@code .../directory{{path ?? ''}}/{{Page.folderName}}},
+ * with the PATH guarded and the NAME not. A `{{path}}` that resolves to nothing
+ * renders as the four characters {@code undefined}, so clicking Create on an
+ * empty New-folder box created a folder genuinely NAMED "undefined". Dev had 115
+ * of them across dozens of clients before this existed.
+ *
+ * Guarding the nine pages that share that shape is whack-a-mole; the names have
+ * to be refused where they are written. Rejecting rather than silently skipping
+ * is deliberate: a 400 is what makes the remaining callers findable.
+ */
+public class FileNameUtil {
+
+    private FileNameUtil() {
+    }
+
+    /**
+     * What a value stringifies to in JavaScript when it is not there. None of
+     * these is a name anybody types on purpose, and every one of them is
+     * evidence of an unguarded interpolation upstream. Compared case
+     * insensitively, which costs a folder honestly called "Null" -- a trade
+     * worth making against corrupting the tree.
+     */
+    private static final Set<String> STRINGIFIED_NOTHING = Set.of(
+            "undefined", "null", "nan", "[object object]", "[object undefined]");
+
+    /** Segments a path may not contain, whatever the storage underneath. */
+    private static final Set<String> RESERVED = Set.of(".", "..");
+
+    public static void validate(String name) {
+
+        if (name == null || name.isBlank())
+            throw new GenericException(HttpStatus.BAD_REQUEST,
+                    "A file or folder name cannot be blank.");
+
+        String trimmed = name.trim();
+
+        if (RESERVED.contains(trimmed))
+            throw new GenericException(HttpStatus.BAD_REQUEST,
+                    "'" + trimmed + "' is not a usable file or folder name.");
+
+        if (STRINGIFIED_NOTHING.contains(trimmed.toLowerCase()))
+            throw new GenericException(HttpStatus.BAD_REQUEST,
+                    "'" + trimmed + "' is not a usable name. It is what an empty value looks like"
+                            + " once it has been put into a URL, so the caller most likely sent a"
+                            + " path with a missing part in it.");
+
+        // A separator inside a single segment would silently deepen the tree,
+        // and a control character is never intended.
+        for (int i = 0; i < trimmed.length(); i++) {
+            char c = trimmed.charAt(i);
+            if (c == '/' || c == '\\' || c < 0x20 || c == 0x7F)
+                throw new GenericException(HttpStatus.BAD_REQUEST,
+                        "A file or folder name cannot contain a path separator or a control"
+                                + " character.");
+        }
+    }
+
+    /** True when the name would be refused, for callers that filter rather than fail. */
+    public static boolean isUsable(String name) {
+        try {
+            validate(name);
+            return true;
+        } catch (GenericException e) {
+            return false;
+        }
+    }
+}

--- a/files/src/test/java/com/modlix/saas/files/util/FileNameUtilTest.java
+++ b/files/src/test/java/com/modlix/saas/files/util/FileNameUtilTest.java
@@ -1,0 +1,107 @@
+package com.modlix.saas.files.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.modlix.saas.commons2.exception.GenericException;
+
+class FileNameUtilTest {
+
+    @Nested
+    @DisplayName("names that are an unguarded interpolation, not a name")
+    class StringifiedNothing {
+
+        /**
+         * The one that actually happened: 115 folders named "undefined" on dev,
+         * from `.../directory{{path ?? ''}}/{{Page.folderName}}` with an empty
+         * name box.
+         */
+        @ParameterizedTest
+        @ValueSource(strings = { "undefined", "UNDEFINED", "Undefined", "null", "NaN",
+                "[object Object]", "[object object]" })
+        @DisplayName("refused, whatever the case")
+        void refused(String name) {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate(name));
+        }
+
+        @Test
+        @DisplayName("a name that merely CONTAINS one is fine")
+        void containingIsFine() {
+            assertDoesNotThrow(() -> FileNameUtil.validate("undefined-behaviour.pdf"));
+            assertDoesNotThrow(() -> FileNameUtil.validate("nullable"));
+        }
+    }
+
+    @Nested
+    @DisplayName("names that are not names")
+    class Malformed {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "", "   " })
+        @DisplayName("blank is refused")
+        void blank(String name) {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate(name));
+        }
+
+        @Test
+        @DisplayName("a tab-only name is blank too")
+        void tabOnly() {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate("\t"));
+        }
+
+        @Test
+        @DisplayName("null is refused rather than thrown past")
+        void nullName() {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate(null));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { ".", ".." })
+        @DisplayName("the traversal segments are refused")
+        void traversal(String name) {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate(name));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "a/b", "a\\b" })
+        @DisplayName("a separator inside one segment is refused")
+        void separators(String name) {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate(name));
+        }
+
+        @Test
+        @DisplayName("a control character is refused")
+        void controlChar() {
+            assertThrows(GenericException.class, () -> FileNameUtil.validate("a\u0001b"));
+        }
+    }
+
+    @Nested
+    @DisplayName("names people really use")
+    class Allowed {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "docsScreens", "Pan.pdf", "calculator images", "video_test-1",
+                "Adzump text updated themes.xlsx", "Group 1707479488.svg",
+                "699d4dc399e3a015be13c8f4", "CityVille4_1225_68.pdf", "..leading-dots.png", "a" })
+        @DisplayName("allowed")
+        void allowed(String name) {
+            assertDoesNotThrow(() -> FileNameUtil.validate(name));
+        }
+
+        @Test
+        @DisplayName("isUsable answers instead of throwing")
+        void isUsable() {
+            assertFalse(FileNameUtil.isUsable("undefined"));
+            assertTrue(FileNameUtil.isUsable("real.png"));
+        }
+    }
+}

--- a/security/src/main/java/com/fincity/security/controller/ClientUrlController.java
+++ b/security/src/main/java/com/fincity/security/controller/ClientUrlController.java
@@ -3,6 +3,8 @@ package com.fincity.security.controller;
 import java.util.List;
 
 import org.jooq.types.ULong;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,16 +40,27 @@ public class ClientUrlController
     }
 
     /**
-     * An app's LIVE URLs, each labelled with the client it belongs to.
+     * An app's LIVE URLs, a page at a time, each labelled with the client it
+     * belongs to.
      *
      * `clientCode` is optional: omitted means every client's rows that the
      * caller may see, which is what a screen listing an app's addresses wants.
      * Naming one narrows it, and still requires managing that client.
+     *
+     * `urlPattern` and `clientName` are substring filters, and `page` / `size`
+     * come off the standard {@link Pageable}. This answers a {@link Page} and
+     * not a bare list: `cxapp` has 527 rows and every caller was paging and
+     * searching that itself. `sort` is accepted and ignored -- the order is
+     * fixed at client name, pattern, id, so that paging is stable.
      */
     @GetMapping("/urls")
-    public Mono<ResponseEntity<List<ClientUrl>>> getClientUrl(@RequestParam String appCode,
-            @RequestParam(required = false) String clientCode) {
-        return this.service.getClientUrls(appCode, clientCode).map(ResponseEntity::ok);
+    public Mono<ResponseEntity<Page<ClientUrl>>> getClientUrl(@RequestParam String appCode,
+            @RequestParam(required = false) String clientCode,
+            @RequestParam(required = false) String urlPattern,
+            @RequestParam(required = false) String clientName,
+            Pageable pageable) {
+        return this.service.getClientUrls(appCode, clientCode, urlPattern, clientName, pageable)
+                .map(ResponseEntity::ok);
     }
 
     /**

--- a/security/src/main/java/com/fincity/security/dao/ClientUrlDAO.java
+++ b/security/src/main/java/com/fincity/security/dao/ClientUrlDAO.java
@@ -9,6 +9,9 @@ import org.jooq.Field;
 import org.jooq.Record1;
 import org.jooq.impl.DSL;
 import org.jooq.types.ULong;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Component;
 
 import com.fincity.saas.commons.model.condition.AbstractCondition;
@@ -152,10 +155,19 @@ public class ClientUrlDAO extends AbstractUpdatableClientCheckDAO<SecurityClient
     }
 
     /**
-     * An app's LIVE URLs, with each row's client named rather than only numbered.
+     * The character that escapes a literal {@code %} or {@code _} in the two
+     * substring filters below. Any character not otherwise special will do; a
+     * backslash would need doubling through both JOOQ and MySQL, so this is one
+     * fewer thing to get wrong.
+     */
+    private static final char LIKE_ESCAPE = '!';
+
+    /**
+     * An app's LIVE URLs, a page at a time, with each row's client named rather
+     * than only numbered.
      *
-     * `clientCode` is now OPTIONAL. Blank means every client's rows, which is
-     * what the workspace's URLs & SSL pane lists: an app's addresses are spread
+     * `clientCode` is OPTIONAL. Blank means every client's rows, which is what
+     * the workspace's URLs & SSL pane lists: an app's addresses are spread
      * across clients (527 of them on cxapp) and showing one client's at a time
      * hid the rest. The picker there narrows this rather than defining it.
      *
@@ -165,11 +177,28 @@ public class ClientUrlDAO extends AbstractUpdatableClientCheckDAO<SecurityClient
      * would hand every client's hostnames to anyone with read access to the app.
      * The service passes null only for a SYSTEM caller.
      *
+     * `urlPattern` and `clientName` are substring filters, applied server-side
+     * so that a client with hundreds of addresses is searchable without shipping
+     * all of them. Both are case-insensitive by collation, not by `lower()`, so
+     * the index on URL_PATTERN is still usable for the non-leading-wildcard part
+     * of a match. Unlike the generic `/query` route -- which interpolates
+     * STRING_LOOSE_EQUAL straight into `like("%" + value + "%")` -- a `%` or `_`
+     * typed here matches itself: a hostname is exactly the kind of value that
+     * contains an underscore, and a filter that silently turns it into "any
+     * character" gives wrong rows with no sign that it did.
+     *
+     * The sort is FIXED at client name, then pattern, then id, and
+     * `pageable.getSort()` is ignored. The id is not decoration: paging over a
+     * non-total order lets MySQL repeat a row on one page and drop it from
+     * another, and two rows can share a client and a pattern only differing by
+     * URL type, which the caller cannot see.
+     *
      * CODE and NAME are selected under the DTO's own field names so `into`
      * fills them; see the note on those fields for why the write path does not
      * mind.
      */
-    public Mono<List<ClientUrl>> getClientUrls(String appCode, String clientCode, ULong restrictToClientId) {
+    public Mono<Page<ClientUrl>> getClientUrls(String appCode, String clientCode, ULong restrictToClientId,
+            String urlPattern, String clientName, Pageable pageable) {
 
         List<Condition> conditions = new ArrayList<>();
 
@@ -179,22 +208,49 @@ public class ClientUrlDAO extends AbstractUpdatableClientCheckDAO<SecurityClient
         if (!StringUtil.safeIsBlank(clientCode))
             conditions.add(SecurityClient.SECURITY_CLIENT.CODE.eq(clientCode));
 
+        if (!StringUtil.safeIsBlank(urlPattern))
+            conditions.add(contains(SECURITY_CLIENT_URL.URL_PATTERN, urlPattern));
+
+        if (!StringUtil.safeIsBlank(clientName))
+            conditions.add(contains(SecurityClient.SECURITY_CLIENT.NAME, clientName));
+
         if (restrictToClientId != null)
             conditions.add(SECURITY_CLIENT_URL.CLIENT_ID.in(
                     this.dslContext.select(SECURITY_CLIENT_HIERARCHY.CLIENT_ID)
                             .from(SECURITY_CLIENT_HIERARCHY)
                             .where(ClientHierarchyDAO.getManageClientCondition(restrictToClientId))));
 
+        Condition where = DSL.and(conditions);
+
         List<Field<?>> fields = new ArrayList<>(Arrays.asList(SECURITY_CLIENT_URL.fields()));
         fields.add(SecurityClient.SECURITY_CLIENT.CODE.as("client_code"));
         fields.add(SecurityClient.SECURITY_CLIENT.NAME.as("client_name"));
 
-        return Flux.from(this.dslContext.select(fields).from(SECURITY_CLIENT_URL)
+        // The count carries the SAME left join, not because it needs a column
+        // from it but because `clientCode` and `clientName` filter on it. A
+        // count over the bare table would answer for a different query.
+        Mono<Integer> count = Mono.from(this.dslContext.selectCount().from(SECURITY_CLIENT_URL)
                 .leftJoin(SecurityClient.SECURITY_CLIENT)
                 .on(SecurityClient.SECURITY_CLIENT.ID.eq(SECURITY_CLIENT_URL.CLIENT_ID))
-                .where(DSL.and(conditions))
-                .orderBy(SecurityClient.SECURITY_CLIENT.NAME.asc(), SECURITY_CLIENT_URL.URL_PATTERN.asc()))
+                .where(where))
+                .map(Record1::value1);
+
+        Mono<List<ClientUrl>> rows = Flux.from(this.dslContext.select(fields).from(SECURITY_CLIENT_URL)
+                .leftJoin(SecurityClient.SECURITY_CLIENT)
+                .on(SecurityClient.SECURITY_CLIENT.ID.eq(SECURITY_CLIENT_URL.CLIENT_ID))
+                .where(where)
+                .orderBy(SecurityClient.SECURITY_CLIENT.NAME.asc(), SECURITY_CLIENT_URL.URL_PATTERN.asc(),
+                        SECURITY_CLIENT_URL.ID.asc())
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset()))
                 .map(rec -> rec.into(ClientUrl.class))
                 .collectList();
+
+        return rows.flatMap(list -> count.map(c -> PageableExecutionUtils.getPage(list, pageable, () -> c)));
+    }
+
+    /** A case-insensitive substring match in which `%` and `_` are literal. */
+    private static Condition contains(Field<String> field, String value) {
+        return field.like("%" + DSL.escape(value, LIKE_ESCAPE) + "%", LIKE_ESCAPE);
     }
 }

--- a/security/src/main/java/com/fincity/security/service/ClientUrlService.java
+++ b/security/src/main/java/com/fincity/security/service/ClientUrlService.java
@@ -13,6 +13,7 @@ import java.util.regex.Pattern;
 import org.jooq.types.ULong;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -55,6 +56,13 @@ public class ClientUrlService
     private static final String URL_PATTERN = "urlPattern";
 
     private static final String CLIENT_URL = "Client URL";
+
+    /**
+     * Rows per page when the caller names none, matched to what the workspace's
+     * URLs & SSL table shows. Small on purpose: the point of paging this route
+     * was that an unbounded answer is what made that pane unusable.
+     */
+    public static final int DEFAULT_URL_PAGE_SIZE = 20;
 
     private final CacheService cacheService;
 
@@ -496,10 +504,19 @@ public class ClientUrlService
      *   caller's own client id and scopes the rows to the hierarchy it manages.
      *   Null goes down only for a SYSTEM caller. Read access to the app alone
      *   must not reveal every client's hostnames.
+     *
+     * Paged, and filterable on the two things a person actually looks for: a
+     * substring of the hostname and a substring of the client's name. `cxapp`
+     * answers on 527 addresses, and returning all of them was one response the
+     * caller then had to page and search for itself. A null `pageable` means the
+     * first page at {@value #DEFAULT_URL_PAGE_SIZE}; the sort is fixed in the
+     * DAO and any sort on the pageable is ignored.
      */
-    public Mono<List<ClientUrl>> getClientUrls(String appCode, String clientCode) {
+    public Mono<Page<ClientUrl>> getClientUrls(String appCode, String clientCode, String urlPattern,
+            String clientName, Pageable pageable) {
 
         boolean allClients = StringUtil.safeIsBlank(clientCode);
+        Pageable page = pageable == null ? PageRequest.of(0, DEFAULT_URL_PAGE_SIZE) : pageable;
 
         return FlatMapUtil.flatMapMono(
 
@@ -512,7 +529,8 @@ public class ClientUrlService
                                 .filter(BooleanUtil::safeValueOf),
 
                 (ca, hasAccess, hasClientAccess) -> this.dao.getClientUrls(appCode, clientCode,
-                        allClients && !ca.isSystemClient() ? ULongUtil.valueOf(ca.getUser().getClientId()) : null))
+                        allClients && !ca.isSystemClient() ? ULongUtil.valueOf(ca.getUser().getClientId()) : null,
+                        urlPattern, clientName, page))
                 .switchIfEmpty(this.msgService.throwMessage(msg -> new GenericException(HttpStatus.FORBIDDEN, msg),
                         SecurityMessageResourceService.FORBIDDEN_WRITE_APPLICATION_ACCESS))
                 .contextWrite(Context.of(LogUtil.METHOD_NAME, "ClientUrlService.getClientUrls"));

--- a/security/src/test/java/com/fincity/security/controller/ClientUrlControllerTest.java
+++ b/security/src/test/java/com/fincity/security/controller/ClientUrlControllerTest.java
@@ -1,8 +1,10 @@
 package com.fincity.security.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -14,6 +16,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -129,17 +134,41 @@ class ClientUrlControllerTest {
             url2.setUrlPattern("https://app2.example.com");
             url2.setAppCode("testapp");
 
-            when(clientUrlService.getClientUrls(eq("testapp"), eq("clientA")))
-                    .thenReturn(Mono.just(List.of(url1, url2)));
+            // The route answers a Page now, so the rows are under `content` and
+            // the caller gets a count it can page against.
+            when(clientUrlService.getClientUrls(eq("testapp"), eq("clientA"), isNull(), isNull(),
+                    any(Pageable.class)))
+                    .thenReturn(Mono.just(new PageImpl<>(List.of(url1, url2), PageRequest.of(0, 20), 2)));
 
             webTestClient.get()
                     .uri(BASE_PATH + "/urls?appCode=testapp&clientCode=clientA")
                     .exchange()
                     .expectStatus().isOk()
                     .expectBody()
-                    .jsonPath("$[0].urlPattern").isEqualTo("https://app.example.com")
-                    .jsonPath("$[0].appCode").isEqualTo("testapp")
-                    .jsonPath("$[1].urlPattern").isEqualTo("https://app2.example.com");
+                    .jsonPath("$.content[0].urlPattern").isEqualTo("https://app.example.com")
+                    .jsonPath("$.content[0].appCode").isEqualTo("testapp")
+                    .jsonPath("$.content[1].urlPattern").isEqualTo("https://app2.example.com")
+                    .jsonPath("$.totalElements").isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("GET /urls - passes the substring filters and the page through")
+        void getClientUrl_passesFiltersAndPage() {
+            when(clientUrlService.getClientUrls(eq("testapp"), isNull(), eq("dev.modlix"), eq("Acme"),
+                    any(Pageable.class)))
+                    .thenReturn(Mono.just(new PageImpl<>(List.of(createTestClientUrl()),
+                            PageRequest.of(2, 5), 40)));
+
+            webTestClient.get()
+                    .uri(BASE_PATH + "/urls?appCode=testapp&urlPattern=dev.modlix&clientName=Acme&page=2&size=5")
+                    .exchange()
+                    .expectStatus().isOk()
+                    .expectBody()
+                    .jsonPath("$.totalElements").isEqualTo(40)
+                    .jsonPath("$.totalPages").isEqualTo(8);
+
+            verify(clientUrlService).getClientUrls(eq("testapp"), isNull(), eq("dev.modlix"), eq("Acme"),
+                    argThat(p -> p.getPageNumber() == 2 && p.getPageSize() == 5));
         }
     }
 

--- a/security/src/test/java/com/fincity/security/integration/DraftUrlVisibilityIntegrationTest.java
+++ b/security/src/test/java/com/fincity/security/integration/DraftUrlVisibilityIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import com.fincity.security.dao.ClientUrlDAO;
 import com.fincity.security.dto.ClientUrl;
@@ -121,7 +122,10 @@ class DraftUrlVisibilityIntegrationTest extends AbstractIntegrationTest {
     @DisplayName("the client URL listing does not include the draft either")
     void clientUrlsSkipDraft() {
 
-        List<ClientUrl> urls = this.clientUrlDAO.getClientUrls(this.appCode, this.clientCode, null).block();
+        List<ClientUrl> urls = this.clientUrlDAO
+                .getClientUrls(this.appCode, this.clientCode, null, null, null, PageRequest.of(0, 50))
+                .block()
+                .getContent();
 
         assertThat(urls).extracting(ClientUrl::getUrlPattern).contains(LIVE_HOST);
         assertThat(urls).extracting(ClientUrl::getUrlPattern)

--- a/security/src/test/java/com/fincity/security/integration/dao/ClientUrlDAOIntegrationTest.java
+++ b/security/src/test/java/com/fincity/security/integration/dao/ClientUrlDAOIntegrationTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import com.fincity.security.dao.ClientUrlDAO;
 import com.fincity.security.dto.ClientUrl;
@@ -23,6 +25,9 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 	private ClientUrlDAO clientUrlDAO;
 
 	private static final ULong SYSTEM_CLIENT_ID = ULong.valueOf(1);
+
+	/** Big enough that the existing assertions still see every row they insert. */
+	private static final Pageable PAGE = PageRequest.of(0, 50);
 
 	private ULong testClientId;
 	private String testClientCode;
@@ -290,10 +295,10 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 			insertClientUrl(testClientId, "https://gcurl1-" + ts + ".example.com", testAppCode).block();
 			insertClientUrl(testClientId, "https://gcurl2-" + ts + ".example.com", testAppCode).block();
 
-			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null))
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, null, null, PAGE))
 					.assertNext(urls -> {
 						assertNotNull(urls);
-						assertEquals(2, urls.size());
+						assertEquals(2, urls.getTotalElements());
 						for (ClientUrl url : urls) {
 							assertEquals(testClientId, url.getClientId());
 							assertEquals(testAppCode.trim(), url.getAppCode().trim());
@@ -306,7 +311,7 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 		@Test
 		@DisplayName("returns empty list for non-existent clientCode")
 		void nonExistentClientCode_ReturnsEmptyList() {
-			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, "NOEXIST", null))
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, "NOEXIST", null, null, null, PAGE))
 					.assertNext(urls -> {
 						assertNotNull(urls);
 						assertTrue(urls.isEmpty());
@@ -320,7 +325,7 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 			String ts = String.valueOf(System.currentTimeMillis());
 			insertClientUrl(testClientId, "https://noapp-" + ts + ".example.com", testAppCode).block();
 
-			StepVerifier.create(clientUrlDAO.getClientUrls("nonExistentApp", testClientCode, null))
+			StepVerifier.create(clientUrlDAO.getClientUrls("nonExistentApp", testClientCode, null, null, null, PAGE))
 					.assertNext(urls -> {
 						assertNotNull(urls);
 						assertTrue(urls.isEmpty());
@@ -344,7 +349,7 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 			insertClientUrl(testClientId, "https://diffapp-" + ts + ".example.com", otherAppCode).block();
 
 			// Query with the original testAppCode should not return URLs from otherAppCode
-			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null))
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, null, null, PAGE))
 					.assertNext(urls -> {
 						assertNotNull(urls);
 						assertTrue(urls.stream().noneMatch(u -> u.getUrlPattern().contains("diffapp-" + ts)));
@@ -361,11 +366,88 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 			ULong otherClientId = insertTestClient(otherCode, "Diff Client", "BUS").block();
 			insertClientUrl(otherClientId, "https://diffcli-" + ts + ".example.com", testAppCode).block();
 
-			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null))
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, null, null, PAGE))
 					.assertNext(urls -> {
 						assertNotNull(urls);
 						assertTrue(urls.stream().noneMatch(u -> u.getUrlPattern().contains("diffcli-" + ts)));
 					})
+					.verifyComplete();
+		}
+
+		@Test
+		@DisplayName("urlPattern narrows to a substring of the hostname")
+		void urlPatternFilter_Narrows() {
+			String ts = String.valueOf(System.currentTimeMillis());
+
+			insertClientUrl(testClientId, "https://alpha-" + ts + ".example.com", testAppCode).block();
+			insertClientUrl(testClientId, "https://beta-" + ts + ".example.com", testAppCode).block();
+
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, "alpha-" + ts, null,
+					PAGE))
+					.assertNext(urls -> {
+						assertEquals(1, urls.getTotalElements());
+						assertTrue(urls.getContent().get(0).getUrlPattern().contains("alpha-" + ts));
+					})
+					.verifyComplete();
+		}
+
+		@Test
+		@DisplayName("an underscore in the urlPattern filter is a literal, not a wildcard")
+		void urlPatternFilter_UnderscoreIsLiteral() {
+			String ts = String.valueOf(System.currentTimeMillis());
+
+			insertClientUrl(testClientId, "https://a_b-" + ts + ".example.com", testAppCode).block();
+			insertClientUrl(testClientId, "https://axb-" + ts + ".example.com", testAppCode).block();
+
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, "a_b-" + ts, null,
+					PAGE))
+					.assertNext(urls -> {
+						assertEquals(1, urls.getTotalElements(),
+								"an unescaped LIKE would have matched axb- as well");
+						assertTrue(urls.getContent().get(0).getUrlPattern().contains("a_b-"));
+					})
+					.verifyComplete();
+		}
+
+		@Test
+		@DisplayName("clientName narrows to a substring of the client's name")
+		void clientNameFilter_Narrows() {
+			String ts = String.valueOf(System.currentTimeMillis());
+			String otherCode = "CN" + ts.substring(ts.length() - 6);
+
+			ULong otherClientId = insertTestClient(otherCode, "Zzmarker " + ts, "BUS").block();
+			insertClientUrl(otherClientId, "https://named-" + ts + ".example.com", testAppCode).block();
+			insertClientUrl(testClientId, "https://unnamed-" + ts + ".example.com", testAppCode).block();
+
+			// No clientCode: the filter is what picks the client, across all of them.
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, null, null, null, "Zzmarker " + ts, PAGE))
+					.assertNext(urls -> {
+						assertEquals(1, urls.getTotalElements());
+						assertEquals(otherClientId, urls.getContent().get(0).getClientId());
+					})
+					.verifyComplete();
+		}
+
+		@Test
+		@DisplayName("pages, and the total counts every match rather than the page")
+		void paging_CountsAllMatches() {
+			String ts = String.valueOf(System.currentTimeMillis());
+
+			for (int i = 0; i < 5; i++)
+				insertClientUrl(testClientId, "https://pg" + i + "-" + ts + ".example.com", testAppCode).block();
+
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, null, null,
+					PageRequest.of(0, 2)))
+					.assertNext(urls -> {
+						assertEquals(2, urls.getContent().size());
+						assertEquals(5, urls.getTotalElements());
+						assertEquals(3, urls.getTotalPages());
+					})
+					.verifyComplete();
+
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, null, null,
+					PageRequest.of(2, 2)))
+					.assertNext(urls -> assertEquals(1, urls.getContent().size(), "last page is the remainder"))
 					.verifyComplete();
 		}
 
@@ -376,12 +458,12 @@ class ClientUrlDAOIntegrationTest extends AbstractIntegrationTest {
 
 			insertClientUrl(testClientId, "https://fields-" + ts + ".example.com", testAppCode).block();
 
-			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null))
+			StepVerifier.create(clientUrlDAO.getClientUrls(testAppCode, testClientCode, null, null, null, PAGE))
 					.assertNext(urls -> {
 						assertNotNull(urls);
-						assertEquals(1, urls.size());
+						assertEquals(1, urls.getTotalElements());
 
-						ClientUrl url = urls.get(0);
+						ClientUrl url = urls.getContent().get(0);
 						assertNotNull(url.getId());
 						assertEquals(testClientId, url.getClientId());
 						assertEquals("https://fields-" + ts + ".example.com", url.getUrlPattern());

--- a/ui/src/main/java/com/fincity/saas/ui/controller/UniversalController.java
+++ b/ui/src/main/java/com/fincity/saas/ui/controller/UniversalController.java
@@ -1,11 +1,10 @@
 package com.fincity.saas.ui.controller;
 
-import java.time.Duration;
+import java.net.URI;
 import java.time.ZoneOffset;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.MimeTypeUtils;
@@ -171,51 +170,110 @@ public class UniversalController {
         return this.securityService.token(token).map(ResponseEntity::ok);
     }
 
+    /**
+     * The cross-app SSO beacon, always a TOP-LEVEL navigation.
+     *
+     * There used to be an iframe/postMessage mode here as well. It could never work across
+     * registrable domains: storage reached from a third-party context is partitioned by
+     * top-level site, so the session this origin really holds is invisible from inside
+     * another app's page in every current browser. It has been removed rather than left as a
+     * path that silently returns "no session" to everyone.
+     */
     @GetMapping(value = "/hassso", produces = MimeTypeUtils.TEXT_HTML_VALUE)
     public Mono<ResponseEntity<String>> hassso(
-            @RequestParam String parentURL,
             @RequestParam String targetAppCode,
             @RequestParam(required = false, defaultValue = "") String targetClientCode,
-            @RequestParam(required = false) Boolean designMode) {
+            @RequestParam(required = false, defaultValue = "") String returnUrl) {
 
-        String safeParentURL = jsString(parentURL);
-        String safeTargetAppCode = jsString(targetAppCode);
-        String safeTargetClientCode = jsString(targetClientCode);
-        // The parent passes designMode explicitly because /hassso always runs in an iframe.
-        String designModeJs = designMode == null
-                ? "var designMode=window.self!==window.top;"
-                : "var designMode=" + designMode + ";";
-
-        String script =
-                "var parentURL=" + safeParentURL + ";" +
-                "var targetAppCode=" + safeTargetAppCode + ";" +
-                "var targetClientCode=" + safeTargetClientCode + ";" +
-                "var parentOrigin=new URL(parentURL).origin;" +
-                designModeJs +
-                "var tokenKey=(designMode?'designMode_':'')+'AuthToken';" +
-                "var expiryKey=(designMode?'designMode_':'')+'AuthTokenExpiry';" +
-                "function postNone(){window.parent.postMessage({type:'sso:none'},parentOrigin);}" +
-                "function postToken(t){window.parent.postMessage({type:'sso:token',token:t},parentOrigin);}" +
-                "var lsToken=localStorage.getItem(tokenKey);" +
-                "var lsExpiry=parseInt(localStorage.getItem(expiryKey)||'0',10)*1000;" +
-                "if(!lsToken||lsExpiry<Date.now()){postNone();}" +
-                "else{" +
-                "var bearer;try{bearer=JSON.parse(lsToken);}catch(e){bearer=lsToken;}" +
-                "fetch('/api/security/makeOneTimeToken',{method:'POST',headers:{'Content-Type':'application/json','Authorization':bearer,'appCode':'authzump','clientCode':'SYSTEM'},body:JSON.stringify({targetAppCode:targetAppCode,targetClientCode:targetClientCode})})" +
-                ".then(function(r){return r.ok?r.json():null;})" +
-                ".then(function(d){if(d&&d.token){postToken(d.token);}else{postNone();}})" +
-                ".catch(function(){postNone();});" +
-                "}";
-
-        String htmlContent = START + script + END;
-
-        return Mono.just(ResponseEntity.ok()
-                .header("Content-Security-Policy", "frame-ancestors *")
-                .header(HttpHeaders.CACHE_CONTROL, "no-store")
-                .body(htmlContent));
+        return this.hasssoBounce(targetAppCode, targetClientCode, returnUrl);
     }
 
-    private static String jsString(String s) {
+    private static ResponseEntity<String> beaconResponse(String htmlContent) {
+        return ResponseEntity.ok()
+                .header("Content-Security-Policy", "frame-ancestors *")
+                .header(HttpHeaders.CACHE_CONTROL, "no-store")
+                .body(htmlContent);
+    }
+
+    /**
+     * The cold-start half of cross-domain SSO, as a TOP-LEVEL navigation instead of an
+     * iframe.
+     * <p>
+     * The iframe path above cannot work across registrable domains: storage reached from a
+     * third-party context is partitioned by top-level site, so what one app writes here is
+     * invisible to the next. Loaded top-level, this page reads the beacon origin's own
+     * first-party storage, mints a one-time token and hands it back on the URL. No
+     * third-party cookie, no Storage Access API, no prompt, and it works in every browser.
+     * <p>
+     * {@code returnUrl} is attacker-controlled and the token is a session, so an open
+     * redirect here is an account takeover. It is checked against the platform's own record:
+     * the host must resolve to the very app the token is being minted for. An unknown host
+     * resolves to appCode "nothing" and is refused.
+     */
+    private Mono<ResponseEntity<String>> hasssoBounce(String targetAppCode, String targetClientCode,
+            String returnUrl) {
+
+        URI uri = absoluteHttpUri(returnUrl);
+
+        if (uri == null || StringUtil.safeIsBlank(targetAppCode))
+            return Mono.just(RESPONSE_BAD_REQUEST);
+
+        return this.securityService
+                .getClientNAppCodeNType(uri.getScheme(), uri.getHost(),
+                        uri.getPort() < 0 ? "" : String.valueOf(uri.getPort()))
+                .filter(t -> targetAppCode.equals(t.getT2()))
+                .map(t -> beaconResponse(START + bounceScript(returnUrl, targetAppCode, targetClientCode) + END))
+                .defaultIfEmpty(RESPONSE_NOT_FOUND);
+    }
+
+    /**
+     * Reads the beacon origin's first-party token, then leaves, one way or the other. The
+     * caller is told "no session" explicitly rather than being left to time out, because it
+     * has to record that it asked and stop asking on every page load.
+     */
+    private static String bounceScript(String returnUrl, String targetAppCode, String targetClientCode) {
+
+        return "var back=" + jsString(returnUrl) + ";" +
+                "var targetAppCode=" + jsString(targetAppCode) + ";" +
+                "var targetClientCode=" + jsString(targetClientCode) + ";" +
+                "function leave(k,v){var u=new URL(back);u.searchParams.set(k,v);window.location.replace(u.toString());}" +
+                "var lsToken=localStorage.getItem('AuthToken');" +
+                "var lsExpiry=parseInt(localStorage.getItem('AuthTokenExpiry')||'0',10)*1000;" +
+                "if(!lsToken||lsExpiry<Date.now()){leave('sso','none');}" +
+                "else{" +
+                "var bearer;try{bearer=JSON.parse(lsToken);}catch(e){bearer=lsToken;}" +
+                "fetch('/api/security/makeOneTimeToken',{method:'POST',headers:{'Content-Type':'application/json',"
+                + "'Authorization':bearer,'appCode':'authzump','clientCode':'SYSTEM'},"
+                + "body:JSON.stringify({targetAppCode:targetAppCode,targetClientCode:targetClientCode})})" +
+                ".then(function(r){return r.ok?r.json():null;})" +
+                ".then(function(d){if(d&&d.token){leave('ott',d.token);}else{leave('sso','none');}})" +
+                ".catch(function(){leave('sso','none');});" +
+                "}";
+    }
+
+    /** An absolute http(s) URI, or null. Anything else is not a place to send a session. */
+    // Package-private so HasssoBounceTest can exercise the return-URL check directly.
+    static URI absoluteHttpUri(String value) {
+
+        if (StringUtil.safeIsBlank(value))
+            return null;
+
+        URI uri;
+        try {
+            uri = URI.create(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")))
+            return null;
+
+        return StringUtil.safeIsBlank(uri.getHost()) ? null : uri;
+    }
+
+    // Package-private so SsoRedirectGuardTest can exercise the escaping directly.
+    static String jsString(String s) {
         if (s == null)
             return "''";
         StringBuilder sb = new StringBuilder(s.length() + 2);
@@ -246,8 +304,6 @@ public class UniversalController {
             @RequestHeader(required = false) String appCode,
             @RequestHeader(value = "X-Real-IP", required = false) String ipAddress,
             @RequestParam(required = false, defaultValue = "/") String redirectUrl,
-            @RequestParam(defaultValue = "false") boolean cookie,
-            @RequestParam(required = false) Boolean designMode,
             ServerHttpRequest request) {
 
         String addr = ipAddress;
@@ -255,36 +311,86 @@ public class UniversalController {
             addr = request.getRemoteAddress() == null ? "" : request.getRemoteAddress().getAddress().getHostAddress();
         }
 
-        // The caller passes designMode when /sso/{token} runs inside a hidden iframe
-        // (where window.self !== window.top would always be true). For top-level legacy
-        // callers (magic link, password reset) we fall back to the existing detection.
-        String designModeJs = designMode == null
-                ? "var designMode = window.self !== window.top;"
-                : "var designMode = " + designMode + ";";
+        String redirectionScript = "window.location.href = " + jsString(sameOriginRedirect(redirectUrl, request)) + ";";
 
         return this.securityService.authenticateWithOneTimeToken(token, forwardedHost, clientCode, appCode, addr)
                 .map(ca -> {
-                    String storeTokenScript = designModeJs +
-                            "window.localStorage.setItem((designMode ? 'designMode_' : '')+'AuthToken', '\""
-                            + ca.getAccessToken()
-                            + "\"');window.localStorage.setItem((designMode ? 'designMode_' : '')+'AuthTokenExpiry', '"
+                    // The token is stored JSON-encoded because /hassso reads it back with
+                    // JSON.parse; jsString then makes the whole value a safe JS literal.
+                    String storeTokenScript =
+                            "window.localStorage.setItem('AuthToken', "
+                            + jsString("\"" + ca.getAccessToken() + "\"")
+                            + ");window.localStorage.setItem('AuthTokenExpiry', '"
                             + ca.getAccessTokenExpiryAt().toEpochSecond(ZoneOffset.UTC) + "');";
-                    String redirectionScript = "window.location.href = '" + redirectUrl + "';";
                     String htmlContent = START + storeTokenScript + redirectionScript + END;
-                    ResponseEntity.BodyBuilder responseBuilder = ResponseEntity.ok()
-                            .header("Content-Security-Policy", "frame-ancestors *");
 
-                    if (cookie) {
-                        ResponseCookie responseCookie = ResponseCookie
-                                .from("AuthToken", ca.getAccessToken())
-                                .path("/")
-                                .maxAge(Duration.ofSeconds(
-                                        ca.getAccessTokenExpiryAt().toEpochSecond(ZoneOffset.UTC)))
-                                .build();
-                        responseBuilder.header(HttpHeaders.SET_COOKIE, responseCookie.toString());
-                    }
-
-                    return responseBuilder.body(htmlContent);
+                    return ResponseEntity.ok()
+                            .header("Content-Security-Policy", "frame-ancestors *")
+                            .body(htmlContent);
                 });
+    }
+
+    /**
+     * Guards the post-SSO redirect against open-redirect abuse. {@link #jsString(String)}
+     * stops the value breaking out of the inline script; this stops it pointing somewhere
+     * else.
+     * <p>
+     * Every caller lands the user back on the origin that served this hop: the SSO beacon
+     * returns to the beacon host, and the legacy appLogin flow substitutes the redirect
+     * into the target app's own {@code properties.sso.callbackURL} template, so the
+     * callback host and the redirect host are the same app by construction. Social login
+     * does not come through here at all — its cross-origin hop is a 302 out of
+     * {@code ClientRegistrationService.registerWSocialCallback}, guarded separately by
+     * {@code isAllowedSocialRedirect}.
+     * <p>
+     * Anything rejected falls back to "/" on the same host rather than failing the login.
+     */
+    static String sameOriginRedirect(String redirectUrl, ServerHttpRequest request) {
+
+        if (redirectUrl == null || redirectUrl.isBlank())
+            return "/";
+
+        // A single leading slash is a same-origin path. "//host" and "/\host" are
+        // protocol-relative URLs that browsers resolve against another origin.
+        if (redirectUrl.charAt(0) == '/')
+            return redirectUrl.length() > 1 && (redirectUrl.charAt(1) == '/' || redirectUrl.charAt(1) == '\\')
+                    ? "/"
+                    : redirectUrl;
+
+        URI uri;
+        try {
+            uri = URI.create(redirectUrl);
+        } catch (IllegalArgumentException e) {
+            return "/";
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")))
+            return "/";
+
+        // getHost() resolves "https://trusted.example@evil.example/" to evil.example, so
+        // a userinfo prefix cannot spoof the comparison.
+        String host = uri.getHost();
+        String ownHost = clientFacingHost(request);
+
+        return host != null && host.equalsIgnoreCase(ownHost) ? redirectUrl : "/";
+    }
+
+    /**
+     * X-Forwarded-Host carries one value per proxy hop joined with commas, and any single
+     * value may include a {@code :port} suffix. The client-facing host is the first entry
+     * with the port stripped.
+     */
+    static String clientFacingHost(ServerHttpRequest request) {
+
+        String raw = request.getHeaders().getFirst("X-Forwarded-Host");
+
+        if (raw == null || raw.isBlank())
+            return request.getURI().getHost();
+
+        int comma = raw.indexOf(',');
+        String first = (comma >= 0 ? raw.substring(0, comma) : raw).trim();
+        int colon = first.indexOf(':');
+        return colon >= 0 ? first.substring(0, colon) : first;
     }
 }

--- a/ui/src/main/java/com/fincity/saas/ui/service/ApplicationService.java
+++ b/ui/src/main/java/com/fincity/saas/ui/service/ApplicationService.java
@@ -297,14 +297,6 @@ public class ApplicationService extends AbstractUIOverridableDataService<Applica
                         object.getProperties().remove("manifest");
                     }
 
-                    if (object.getProperties().get("sso") instanceof Map<?, ?> sso) {
-
-                        String url = StringUtil.safeValueOf(sso.get("redirectURL"));
-                        if (url != null) {
-                            ((Map<String, String>) sso).put("redirectURL", processForVariables(url));
-                        }
-                    }
-
                     if (shellPage == null) {
 
                         if (filler == null)

--- a/ui/src/main/java/com/fincity/saas/ui/service/IndexHTMLService.java
+++ b/ui/src/main/java/com/fincity/saas/ui/service/IndexHTMLService.java
@@ -69,6 +69,8 @@ public class IndexHTMLService {
 
     private static final String KEY_ENABLED = "enabled";
 
+    private static final String LOCAL_ENV = "local";
+
     private static final Map<String, Integer> CODE_PART_PLACES = Map.of("AFTER_HEAD", 0, "BEFORE_HEAD", 1, "AFTER_BODY",
             2, "BEFORE_BODY", 3);
 
@@ -582,15 +584,24 @@ public class IndexHTMLService {
      *   ""        -> "authzump.ai"
      *   ".dev"    -> "dev.authzump.ai"
      *   ".stage"  -> "stage.authzump.ai"
-     *   ".local"  -> "local.authzump.ai"
+     *   ".local"  -> "authzump.local.modlix.com"
+     * <p>
+     * Local is deliberately not "local.authzump.ai". Local hosts are
+     * {@code <app>.local.modlix.com} (dnsmasq wildcards that suffix to 127.0.0.1 on a
+     * developer machine); the .ai names belong to the deployed environments only.
+     * "local.authzump.ai" does resolve, to prod-lb, where it is a stray vhost carrying
+     * appCode "nothing" -- so pointing the beacon there silently broke all local SSO.
      */
-    private static String deriveBeaconHost(String appCodeSuffix) {
+    // Package-private so BeaconHostTest can pin the per-environment mapping.
+    static String deriveBeaconHost(String appCodeSuffix) {
         if (StringUtil.safeIsBlank(appCodeSuffix))
             return "authzump.ai";
         String trimmed = appCodeSuffix.startsWith(".") ? appCodeSuffix.substring(1) : appCodeSuffix;
         int dotIdx = trimmed.indexOf('.');
         String env = dotIdx >= 0 ? trimmed.substring(0, dotIdx) : trimmed;
-        return StringUtil.safeIsBlank(env) ? "authzump.ai" : env + ".authzump.ai";
+        if (StringUtil.safeIsBlank(env))
+            return "authzump.ai";
+        return LOCAL_ENV.equals(env) ? "authzump." + env + ".modlix.com" : env + ".authzump.ai";
     }
 
     @SuppressWarnings("unchecked")

--- a/ui/src/test/java/com/fincity/saas/ui/controller/HasssoBounceTest.java
+++ b/ui/src/test/java/com/fincity/saas/ui/controller/HasssoBounceTest.java
@@ -1,0 +1,63 @@
+package com.fincity.saas.ui.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The /hassso bounce hands a one-time token to returnUrl, so an open redirect here is an
+ * account takeover. Two things stand in the way: the URL must be an absolute http(s) address,
+ * and its host must resolve to the very app the token is for. This covers the first.
+ */
+class HasssoBounceTest {
+
+    @Test
+    void acceptsAbsoluteHttpAddresses() {
+
+        URI u = UniversalController.absoluteHttpUri("https://leadzump.ai/deals?x=1");
+        assertNotNull(u);
+        assertEquals("leadzump.ai", u.getHost());
+        assertEquals("https", u.getScheme());
+
+        assertNotNull(UniversalController.absoluteHttpUri("http://leadzump.local.modlix.com:8002/"));
+        // Scheme case must not matter; hosts and schemes are case-insensitive.
+        assertNotNull(UniversalController.absoluteHttpUri("HTTPS://leadzump.ai/"));
+    }
+
+    @Test
+    void refusesAnythingThatIsNotAPlaceToSendASession() {
+
+        assertNull(UniversalController.absoluteHttpUri(null));
+        assertNull(UniversalController.absoluteHttpUri(""));
+        assertNull(UniversalController.absoluteHttpUri("   "));
+        // Relative: no host to check against the app, so it cannot be validated at all.
+        assertNull(UniversalController.absoluteHttpUri("/deals"));
+        assertNull(UniversalController.absoluteHttpUri("//leadzump.ai/deals"));
+        // Non-http schemes execute rather than navigate.
+        assertNull(UniversalController.absoluteHttpUri("javascript:alert(1)"));
+        assertNull(UniversalController.absoluteHttpUri("data:text/html,x"));
+        // Unparseable.
+        assertNull(UniversalController.absoluteHttpUri("https://exa mple.com/"));
+    }
+
+    @Test
+    void userinfoCannotSpoofTheHostThatGetsChecked() {
+
+        // The host is what is compared against the app's registered URL, and Java resolves
+        // this to the part after the @, not the part before it.
+        URI u = UniversalController.absoluteHttpUri("https://leadzump.ai@evil.example/steal");
+        assertNotNull(u);
+        assertEquals("evil.example", u.getHost());
+    }
+
+    @Test
+    void portIsCarriedThroughForTheResolverAndAbsentWhenDefault() {
+
+        assertEquals(8002, UniversalController.absoluteHttpUri("http://x.local.modlix.com:8002/a").getPort());
+        assertEquals(-1, UniversalController.absoluteHttpUri("https://leadzump.ai/a").getPort());
+    }
+}

--- a/ui/src/test/java/com/fincity/saas/ui/controller/SsoRedirectGuardTest.java
+++ b/ui/src/test/java/com/fincity/saas/ui/controller/SsoRedirectGuardTest.java
@@ -1,0 +1,71 @@
+package com.fincity.saas.ui.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+
+/**
+ * Guards for /sso/{token}. The endpoint splices redirectUrl into inline JS and then
+ * navigates the browser to it, so both the escaping and the destination check matter.
+ */
+class SsoRedirectGuardTest {
+
+    private static final String OWN_HOST = "sitezump.ai";
+
+    private static ServerHttpRequest requestOn(String forwardedHost) {
+        MockServerHttpRequest.BaseBuilder<?> builder = MockServerHttpRequest.get("https://" + OWN_HOST + "/sso/tkn");
+        if (forwardedHost != null)
+            builder = builder.header("X-Forwarded-Host", forwardedHost);
+        return builder.build();
+    }
+
+    private static String guard(String redirectUrl) {
+        return UniversalController.sameOriginRedirect(redirectUrl, requestOn(OWN_HOST));
+    }
+
+    @Test
+    void escapesAQuoteSoItCannotCloseTheJsStringLiteral() {
+
+        assertEquals("'\\'+alert(1)+\\''", UniversalController.jsString("'+alert(1)+'"));
+        assertEquals("'\\u003c/script\\u003e'", UniversalController.jsString("</script>"));
+        assertEquals("''", UniversalController.jsString(null));
+    }
+
+    @Test
+    void keepsSameOriginDestinations() {
+
+        assertEquals("/", guard("/"));
+        assertEquals("/dashboard?tab=1", guard("/dashboard?tab=1"));
+        assertEquals("https://sitezump.ai/deals", guard("https://sitezump.ai/deals"));
+        // The beacon hop sends the bare origin with no path.
+        assertEquals("https://sitezump.ai", guard("https://sitezump.ai"));
+        // Host comparison is case-insensitive, as hosts are.
+        assertEquals("https://SITEZUMP.AI/x", guard("https://SITEZUMP.AI/x"));
+    }
+
+    @Test
+    void rejectsOtherOriginsBackToTheAppRoot() {
+
+        assertEquals("/", guard("https://evil.example/steal"));
+        // A userinfo prefix must not spoof the host comparison.
+        assertEquals("/", guard("https://sitezump.ai@evil.example/steal"));
+        // Protocol-relative URLs look like paths but resolve to another origin.
+        assertEquals("/", guard("//evil.example/steal"));
+        assertEquals("/", guard("/\\evil.example/steal"));
+        // Non-http schemes are a script-execution vector, not a destination.
+        assertEquals("/", guard("javascript:alert(1)"));
+        assertEquals("/", guard(""));
+        assertEquals("/", guard(null));
+    }
+
+    @Test
+    void takesTheClientFacingHostFromTheFirstForwardedHopWithoutItsPort() {
+
+        assertEquals("sitezump.ai", UniversalController.clientFacingHost(requestOn("sitezump.ai:443, internal-lb")));
+        assertEquals("sitezump.ai", UniversalController.clientFacingHost(requestOn("sitezump.ai")));
+        // With no proxy header the request's own host stands in.
+        assertEquals(OWN_HOST, UniversalController.clientFacingHost(requestOn(null)));
+    }
+}

--- a/ui/src/test/java/com/fincity/saas/ui/service/BeaconHostTest.java
+++ b/ui/src/test/java/com/fincity/saas/ui/service/BeaconHostTest.java
@@ -1,0 +1,39 @@
+package com.fincity.saas.ui.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the SSO beacon host per environment. Getting local wrong points the beacon iframe at
+ * a host that 404s and breaks all local SSO silently, which is exactly what happened before.
+ * <p>
+ * htmlRenderer.ts in nocode-ui/ui-app/ssr carries a copy of this mapping and must agree.
+ */
+class BeaconHostTest {
+
+    @Test
+    void deployedEnvironmentsLiveOnTheAiDomain() {
+
+        assertEquals("authzump.ai", IndexHTMLService.deriveBeaconHost(""));
+        assertEquals("authzump.ai", IndexHTMLService.deriveBeaconHost(null));
+        assertEquals("dev.authzump.ai", IndexHTMLService.deriveBeaconHost(".dev"));
+        assertEquals("stage.authzump.ai", IndexHTMLService.deriveBeaconHost(".stage"));
+        // A leading dot is the convention but not required.
+        assertEquals("dev.authzump.ai", IndexHTMLService.deriveBeaconHost("dev"));
+    }
+
+    @Test
+    void localLivesOnModlixComBecauseThatIsWhatDnsmasqWildcards() {
+
+        assertEquals("authzump.local.modlix.com", IndexHTMLService.deriveBeaconHost(".local"));
+        assertEquals("authzump.local.modlix.com", IndexHTMLService.deriveBeaconHost("local"));
+    }
+
+    @Test
+    void onlyTheFirstSuffixSegmentNamesTheEnvironment() {
+
+        assertEquals("dev.authzump.ai", IndexHTMLService.deriveBeaconHost(".dev.something"));
+        assertEquals("authzump.local.modlix.com", IndexHTMLService.deriveBeaconHost(".local.something"));
+    }
+}


### PR DESCRIPTION
- Updated getClientUrls method to return a paginated response with filtering options for urlPattern and clientName.
- Introduced DEFAULT_URL_PAGE_SIZE constant for default pagination size.
- Modified related tests in ClientUrlControllerTest and ClientUrlDAOIntegrationTest to validate new pagination and filtering functionality.

fix: Improve SSO handling in UniversalController

- Refactored hassso endpoint to ensure proper handling of returnUrl and prevent open redirect vulnerabilities.
- Added utility methods for validating absolute HTTP URIs and ensuring same-origin redirects.

test: Add comprehensive tests for SSO and beacon host functionality

- Created HasssoBounceTest and SsoRedirectGuardTest to validate SSO redirect handling and security.
- Implemented BeaconHostTest to ensure correct mapping of beacon hosts per environment.
- Updated existing tests to align with new functionality and ensure robust coverage.